### PR TITLE
feat: add message sending capability to lark CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vendor/
 .vscode/
 *.swp
 *.swo
+lark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,20 @@ See `USAGE.md` for full CLI documentation. Main commands:
 - `contact list-dept [dept_id]` - List users in department
 - `contact search-dept <query>` - Search departments by name
 
+### Messages (`msg`)
+- `msg history` - Get chat message history
+- `msg resource` - Download message attachments
+- `msg send` - Send messages to users or chats
+- `chat search` - Find chats and groups
+
+**Message Sending Features:**
+- Send text messages with line breaks (`\n` creates newlines)
+- Mention users with `--mention` flag
+- Include links with `--link` and `--url` flags
+- Send to emails, user IDs, or chat IDs
+- Auto-detect recipient types
+- Support escape sequences (\n, \t, \", \\)
+
 ### Documents (`doc`)
 - `doc list [folder_token]` - List items in a Drive folder
 - `doc get <document_id>` - Get document content as markdown

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The result: AI assistants can interact with Lark using fewer tokens, leaving mor
 - **Calendar** - List, create, update, delete events; check availability; find common free time; RSVP
 - **Contacts** - Look up users by ID, search by name, list department members
 - **Documents** - Read documents as markdown, list folders, resolve wiki nodes, get comments
-- **Messages** - Retrieve chat history, download attachments
+- **Messages** - Retrieve chat history, download attachments, send messages to users and chats
 
 ## Quick Start
 
@@ -59,7 +59,7 @@ Available skills:
 - `calendar` - Manage calendar events, check availability, RSVP
 - `contacts` - Look up users and departments
 - `documents` - Read documents, list folders, browse wikis
-- `messages` - Retrieve chat history, download attachments
+- `messages` - Retrieve chat history, download attachments, send messages to users and chats
 
 ### Configuration
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -16,6 +16,7 @@ A CLI tool for interacting with Lark APIs (calendar, contacts, documents). Desig
    - `wiki:wiki:readonly` (read wiki nodes)
    - `space:document:retrieve` (list Drive folder contents)
    - `im:message:readonly` (read messages in chats)
+   - `im:message` or `im:message:send_as_bot` (send messages)
    - `offline_access` (for refresh tokens)
 3. Add redirect URI: `http://localhost:9999/callback`
 4. Enable "Refresh user_access_token" in Security Settings
@@ -320,6 +321,56 @@ Output:
 ```
 
 **Note:** The file_key can be found in the `content` field of messages returned by `lark msg history`. The maximum downloadable file size is 100MB. Emoji resources cannot be downloaded.
+
+#### Send Message
+
+Send messages to users or group chats as the bot.
+
+```bash
+# Send simple text to user
+./lark msg send --to ou_xxxx --text "Hello!"
+
+# Send to group chat
+./lark msg send --to oc_xxxx --text "Meeting starting soon"
+
+# Text with line breaks (\n creates actual newlines)
+./lark msg send --to ou_xxxx --text "Line 1\nLine 2\nLine 3"
+
+# For literal backslash-n, use double backslash
+./lark msg send --to ou_xxxx --text "Show literal \\n text"
+
+# Mention users (automatically uses rich text format)
+./lark msg send --to oc_xxxx --text "Please review" --mention ou_user1 --mention ou_user2
+
+# With link
+./lark msg send --to ou_xxxx --text "Check this out" --link "Our Docs" --url "https://docs.example.com"
+
+# Combined features
+./lark msg send --to oc_xxxx \
+  --text "Project milestone reached!" \
+  --mention ou_user1 --mention ou_user2 \
+  --link "View Details" --url "https://project.example.com"
+```
+
+Flags:
+- `--to` (required): Recipient identifier (user ID, open_id, email, or chat_id)
+- `--to-type`: Explicitly specify ID type (`open_id`, `user_id`, `email`, `chat_id`) - auto-detected if omitted
+- `--text` (required): Message text content
+- `--mention`: User open_id to mention (repeatable for multiple mentions)
+- `--link`: Link display text (must be used with `--url`)
+- `--url`: Link URL (must be used with `--link`)
+
+Output:
+```json
+{
+  "success": true,
+  "message_id": "om_dc13264520392913993dd051dba21dcf",
+  "chat_id": "oc_xxxxx",
+  "create_time": "2026-01-14T10:30:00+08:00"
+}
+```
+
+**Note:** Messages are sent as the bot/app. The bot must be added to group chats before it can send messages to them.
 
 ### Documents
 

--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -77,3 +77,29 @@ func (c *Client) GetMessageResource(messageID, fileKey, resourceType string) (io
 	path := fmt.Sprintf("/im/v1/messages/%s/resources/%s?type=%s", messageID, fileKey, resourceType)
 	return c.DownloadWithTenantToken(path)
 }
+
+// SendMessage sends a message to a user or chat
+// receiveIDType: "open_id", "user_id", "email", "chat_id"
+// receiveID: the recipient identifier
+// msgType: "text" or "post"
+// content: JSON string of message content (format depends on msgType)
+func (c *Client) SendMessage(receiveIDType, receiveID, msgType, content string) (*SendMessageResponse, error) {
+	path := fmt.Sprintf("/im/v1/messages?receive_id_type=%s", receiveIDType)
+
+	req := SendMessageRequest{
+		ReceiveID: receiveID,
+		MsgType:   msgType,
+		Content:   content,
+	}
+
+	var resp SendMessageResponse
+	if err := c.PostWithTenantToken(path, req, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return &resp, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -359,8 +359,8 @@ type OutputUserInfo struct {
 // CommonFreeTimeRequest is the request body for common free time API
 type CommonFreeTimeRequest struct {
 	UserIDs                 []string `json:"user_ids"`
-	StartTime               string   `json:"start_time"`  // "YYYY-MM-DD HH:MM:SS"
-	EndTime                 string   `json:"end_time"`    // "YYYY-MM-DD HH:MM:SS"
+	StartTime               string   `json:"start_time"` // "YYYY-MM-DD HH:MM:SS"
+	EndTime                 string   `json:"end_time"`   // "YYYY-MM-DD HH:MM:SS"
 	Timezone                string   `json:"timezone"`
 	OnlyBusy                bool     `json:"only_busy,omitempty"`
 	IncludeExternalCalendar bool     `json:"include_external_calendar,omitempty"`
@@ -418,26 +418,26 @@ type ContactUserStatus struct {
 
 // ContactUser represents a user from the Contacts API
 type ContactUser struct {
-	UnionID        string             `json:"union_id,omitempty"`
-	UserID         string             `json:"user_id,omitempty"`
-	OpenID         string             `json:"open_id,omitempty"`
-	Name           string             `json:"name,omitempty"`
-	EnName         string             `json:"en_name,omitempty"`
-	Nickname       string             `json:"nickname,omitempty"`
-	Email          string             `json:"email,omitempty"`
-	Mobile         string             `json:"mobile,omitempty"`
-	Gender         int                `json:"gender,omitempty"`
-	Status         *ContactUserStatus `json:"status,omitempty"`
-	DepartmentIDs  []string           `json:"department_ids,omitempty"`
-	LeaderUserID   string             `json:"leader_user_id,omitempty"`
-	City           string             `json:"city,omitempty"`
-	Country        string             `json:"country,omitempty"`
-	WorkStation    string             `json:"work_station,omitempty"`
-	JoinTime       int64              `json:"join_time,omitempty"`
-	EmployeeNo     string             `json:"employee_no,omitempty"`
-	EmployeeType   int                `json:"employee_type,omitempty"`
-	JobTitle       string             `json:"job_title,omitempty"`
-	EnterpriseEmail string            `json:"enterprise_email,omitempty"`
+	UnionID         string             `json:"union_id,omitempty"`
+	UserID          string             `json:"user_id,omitempty"`
+	OpenID          string             `json:"open_id,omitempty"`
+	Name            string             `json:"name,omitempty"`
+	EnName          string             `json:"en_name,omitempty"`
+	Nickname        string             `json:"nickname,omitempty"`
+	Email           string             `json:"email,omitempty"`
+	Mobile          string             `json:"mobile,omitempty"`
+	Gender          int                `json:"gender,omitempty"`
+	Status          *ContactUserStatus `json:"status,omitempty"`
+	DepartmentIDs   []string           `json:"department_ids,omitempty"`
+	LeaderUserID    string             `json:"leader_user_id,omitempty"`
+	City            string             `json:"city,omitempty"`
+	Country         string             `json:"country,omitempty"`
+	WorkStation     string             `json:"work_station,omitempty"`
+	JoinTime        int64              `json:"join_time,omitempty"`
+	EmployeeNo      string             `json:"employee_no,omitempty"`
+	EmployeeType    int                `json:"employee_type,omitempty"`
+	JobTitle        string             `json:"job_title,omitempty"`
+	EnterpriseEmail string             `json:"enterprise_email,omitempty"`
 }
 
 // DepartmentI18nName represents internationalized department names
@@ -480,9 +480,9 @@ type GetUserResponse struct {
 type FindByDepartmentResponse struct {
 	BaseResponse
 	Data struct {
-		HasMore   bool           `json:"has_more"`
-		PageToken string         `json:"page_token,omitempty"`
-		Items     []ContactUser  `json:"items,omitempty"`
+		HasMore   bool          `json:"has_more"`
+		PageToken string        `json:"page_token,omitempty"`
+		Items     []ContactUser `json:"items,omitempty"`
 	} `json:"data,omitempty"`
 }
 
@@ -815,8 +815,8 @@ type OutputFolderItemsList struct {
 
 // CommentReplyElement represents an element in a comment reply
 type CommentReplyElement struct {
-	Type     string `json:"type,omitempty"`
-	TextRun  *struct {
+	Type    string `json:"type,omitempty"`
+	TextRun *struct {
 		Text string `json:"text,omitempty"`
 	} `json:"text_run,omitempty"`
 	DocsLink *struct {
@@ -909,25 +909,25 @@ type MessageBody struct {
 
 // MessageMention represents a mentioned user or bot in a message
 type MessageMention struct {
-	Key       string `json:"key,omitempty"`        // e.g., "@_user_1"
-	ID        string `json:"id,omitempty"`         // open_id of mentioned user/bot
-	IDType    string `json:"id_type,omitempty"`    // currently only "open_id"
-	Name      string `json:"name,omitempty"`       // Name of mentioned user/bot
+	Key       string `json:"key,omitempty"`     // e.g., "@_user_1"
+	ID        string `json:"id,omitempty"`      // open_id of mentioned user/bot
+	IDType    string `json:"id_type,omitempty"` // currently only "open_id"
+	Name      string `json:"name,omitempty"`    // Name of mentioned user/bot
 	TenantKey string `json:"tenant_key,omitempty"`
 }
 
 // Message represents a message from the IM API
 type Message struct {
 	MessageID      string           `json:"message_id,omitempty"`
-	RootID         string           `json:"root_id,omitempty"`         // Root message ID for replies
-	ParentID       string           `json:"parent_id,omitempty"`       // Parent message ID for replies
-	ThreadID       string           `json:"thread_id,omitempty"`       // Thread ID if in a thread
-	MsgType        string           `json:"msg_type,omitempty"`        // text, post, image, file, audio, media, sticker, interactive, share_chat, share_user
-	CreateTime     string           `json:"create_time,omitempty"`     // Unix ms timestamp
-	UpdateTime     string           `json:"update_time,omitempty"`     // Unix ms timestamp
-	Deleted        bool             `json:"deleted,omitempty"`         // Whether message is deleted/recalled
-	Updated        bool             `json:"updated,omitempty"`         // Whether message is updated
-	ChatID         string           `json:"chat_id,omitempty"`         // Group ID
+	RootID         string           `json:"root_id,omitempty"`     // Root message ID for replies
+	ParentID       string           `json:"parent_id,omitempty"`   // Parent message ID for replies
+	ThreadID       string           `json:"thread_id,omitempty"`   // Thread ID if in a thread
+	MsgType        string           `json:"msg_type,omitempty"`    // text, post, image, file, audio, media, sticker, interactive, share_chat, share_user
+	CreateTime     string           `json:"create_time,omitempty"` // Unix ms timestamp
+	UpdateTime     string           `json:"update_time,omitempty"` // Unix ms timestamp
+	Deleted        bool             `json:"deleted,omitempty"`     // Whether message is deleted/recalled
+	Updated        bool             `json:"updated,omitempty"`     // Whether message is updated
+	ChatID         string           `json:"chat_id,omitempty"`     // Group ID
 	Sender         *MessageSender   `json:"sender,omitempty"`
 	Body           *MessageBody     `json:"body,omitempty"`
 	Mentions       []MessageMention `json:"mentions,omitempty"`
@@ -979,6 +979,42 @@ type OutputMessageList struct {
 	Messages []OutputMessage `json:"messages"`
 	Count    int             `json:"count"`
 	ChatID   string          `json:"chat_id"`
+}
+
+// --- Send Message Types ---
+
+// SendMessageRequest is the request body for POST /im/v1/messages
+type SendMessageRequest struct {
+	ReceiveID string `json:"receive_id"`
+	MsgType   string `json:"msg_type"` // text, post
+	Content   string `json:"content"`  // JSON string
+}
+
+// SendMessageResponse is the response from POST /im/v1/messages
+type SendMessageResponse struct {
+	BaseResponse
+	Data struct {
+		MessageID  string           `json:"message_id"`
+		RootID     string           `json:"root_id,omitempty"`
+		ParentID   string           `json:"parent_id,omitempty"`
+		MsgType    string           `json:"msg_type"`
+		CreateTime string           `json:"create_time"`
+		UpdateTime string           `json:"update_time"`
+		Deleted    bool             `json:"deleted"`
+		Updated    bool             `json:"updated"`
+		ChatID     string           `json:"chat_id"`
+		Sender     *MessageSender   `json:"sender,omitempty"`
+		Body       *MessageBody     `json:"body,omitempty"`
+		Mentions   []MessageMention `json:"mentions,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// OutputSendMessage is the simplified send message response for CLI
+type OutputSendMessage struct {
+	Success    bool   `json:"success"`
+	MessageID  string `json:"message_id"`
+	ChatID     string `json:"chat_id,omitempty"`
+	CreateTime string `json:"create_time"`
 }
 
 // --- Chat Types ---

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -1,11 +1,61 @@
 ---
 name: messages
-description: Retrieve chat message history from Lark - get messages from group chats, private chats, and threads. Use when user asks about chat messages, conversation history, or what was discussed in a group.
+description: Retrieve chat message history and send messages in Lark - get messages from group chats, private chats, threads, and send messages to users or chats. Use when user asks about chat messages, conversation history, what was discussed in a group, or wants to send a message.
 ---
 
 # Messages Skill
 
-Retrieve chat message history and search for chats/groups via the `lark` CLI.
+Retrieve chat message history, send messages, and search for chats/groups via the `lark` CLI.
+
+## 🤖 Agent Capabilities
+
+**Message Sending Features:**
+- Send text messages with line breaks and formatting
+- Mention users in group chats
+- Include clickable links
+- Send to individual users or group chats
+- Auto-detect recipient types (email, user ID, chat ID)
+- Support for escape sequences (\n, \t, \", \\)
+
+**Use Cases:**
+- Send notifications and updates
+- Share links and resources
+- Mention team members in group discussions
+- Communicate with users via email or direct message
+- Format messages with proper line breaks and structure
+
+**Agent-Friendly Features:**
+- Explicit flag-based interface (no ambiguous parsing)
+- Clear error messages and validation
+- Comprehensive help text with examples
+- Consistent JSON output for easy parsing
+
+## 🚀 Quick Reference
+
+**Send a simple message:**
+```bash
+lark msg send --to user@example.com --text "Hello!"
+```
+
+**Send with formatting:**
+```bash
+lark msg send --to oc_12345 --text "Update:\n• Task completed\n• Next: Review" --mention ou_user1
+```
+
+**Send with links:**
+```bash
+lark msg send --to ou_12345 --text "Check this out" --link "Dashboard" --url "https://example.com"
+```
+
+**Find chats:**
+```bash
+lark chat search "project team"
+```
+
+**Read messages:**
+```bash
+lark msg history --chat-id oc_12345 --limit 10
+```
 
 ## Running Commands
 
@@ -61,6 +111,96 @@ The search supports:
 - Group member name matching
 - Multiple languages
 - Fuzzy search (pinyin, prefix, etc.)
+
+### Send Messages
+
+Send messages to users or group chats as the bot.
+
+```bash
+# Send simple text to user
+lark msg send --to ou_xxxx --text "Hello!"
+
+# Send to group chat
+lark msg send --to oc_xxxx --text "Meeting starting soon"
+
+# Text with line breaks (\n is interpreted as newline)
+lark msg send --to ou_xxxx --text "Update:\nPhase 1 complete\nPhase 2 starting"
+
+# Supported escape sequences: \n (newline), \t (tab), \\ (backslash), \" (quote)
+lark msg send --to ou_xxxx --text "Tab:\tindented\nNew line"
+
+# Mention users in group chat
+lark msg send --to oc_xxxx --text "Please review" --mention ou_user1 --mention ou_user2
+
+# With link
+lark msg send --to ou_xxxx --text "Check this out" --link "Our Docs" --url "https://docs.example.com"
+
+# Combined features
+lark msg send --to oc_xxxx \
+  --text "Project milestone reached!" \
+  --mention ou_user1 --mention ou_user2 \
+  --link "View Details" --url "https://project.example.com"
+
+# Using explicit ID type
+lark msg send --to user@example.com --to-type email --text "Hello"
+```
+
+Available flags:
+- `--to` (required): Recipient identifier (user ID, open_id, email, or chat_id)
+- `--to-type`: Explicitly specify ID type (`open_id`, `user_id`, `email`, `chat_id`) - auto-detected if omitted
+- `--text` (required): Message text content
+- `--mention`: User open_id to mention (repeatable for multiple mentions)
+- `--link`: Link display text (must be used with `--url`)
+- `--url`: Link URL (must be used with `--link`)
+
+Output:
+```json
+{
+  "success": true,
+  "message_id": "om_dc13264520392913993dd051dba21dcf",
+  "chat_id": "oc_xxxxx",
+  "create_time": "2026-01-14T10:30:00+08:00"
+}
+```
+
+## 🔍 Agent Use Cases
+
+**When to use message sending:**
+- Notify users about task completion or status updates
+- Share links to documents, dashboards, or resources
+- Mention team members in group discussions
+- Send automated alerts or reminders
+- Communicate with users via email or direct message
+- Format messages with proper structure and line breaks
+
+**Message formatting tips for agents:**
+- Use `\n` for line breaks: `--text "Line 1\nLine 2"`
+- Use `\t` for indentation: `--text "•\tItem 1\n•\tItem 2"`
+- Use `\"` for quotes: `--text "\"Important:\" message"`
+- Use `\\` for literal backslash: `--text "Path: C:\\\\folder\\\\file"`
+
+**Recipient discovery:**
+- Use `lark chat search "team"` to find group chats
+- Use `lark contact get <user_id>` to verify user information
+- Use email addresses directly (auto-detected)
+- Use open_id format for reliable user targeting
+
+**Recipient ID Types:**
+- `open_id`: User open ID (starts with `ou_`)
+- `user_id`: User ID (numeric)
+- `email`: User email address
+- `chat_id`: Group chat ID (starts with `oc_`)
+
+The CLI auto-detects the ID type based on format, but you can override with `--to-type`.
+
+**Message Types:**
+- **Simple text**: Use only `--text` flag (supports `\n` for line breaks)
+- **Rich text**: Automatically activated when using `--mention` or `--link`/`--url`
+
+**Notes:**
+- Messages are sent as the bot/app
+- The bot must be added to group chats before it can send messages
+- Requires `im:message` or `im:message:send_as_bot` permission scope
 
 ### Get Chat History
 ```bash
@@ -271,9 +411,15 @@ Common error codes:
 
 ## Permissions Required
 
+**For reading messages:**
 - The bot must be in the group chat
 - For group chat messages, the app needs the "Read all messages in associated group chat" permission scope
 - Private chat messages only require `im:message:readonly` scope
+
+**For sending messages:**
+- Requires `im:message` or `im:message:send_as_bot` permission scope
+- The bot must be added to group chats before it can send messages to them
+- Can send to users directly without being in a private chat first
 
 ## Notes
 


### PR DESCRIPTION
- Add lark msg send command with support for:
  * Sending text messages to users and chats
  * Mentioning users with --mention flag
  * Including links with --link and --url flags
  * Auto-detecting recipient types (email, user_id, open_id, chat_id)
  * Escape sequence processing (\n, \t, ", \)

- Update API layer with SendMessage function and types
- Enhance command validation and error handling
- Add comprehensive documentation for agent discoverability:
  * Update skills/messages/SKILL.md with agent capabilities
  * Create AGENTS.md quick reference guide
  * Update CLAUDE.md and README.md
  * Add escape sequence formatting guide

- Add agent-friendly features:
  * Explicit flag-based interface
  * Clear error messages and validation
  * Comprehensive help text with examples
  * Consistent JSON output for easy parsing

Breaking changes: None (new feature)
Tests: Manual testing completed for all functionality