### PR TITLE
feat: add image support to msg send with {{image}} placeholder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ See `USAGE.md` for full CLI documentation. Main commands:
 
 **Message Sending Features:**
 - Send text messages with line breaks (`\n` creates newlines)
+- Send images with `--image` and place `{{image}}` in text to control placement
 - Mention users with `@{ou_xxx}` placeholders
 - Include links with markdown `[text](url)`
 - Send to emails, user IDs, or chat IDs

--- a/USAGE.md
+++ b/USAGE.md
@@ -370,6 +370,15 @@ Send messages to users or group chats as the bot.
 
 # With link
 ./lark msg send --to ou_xxxx --text "Check this out [Our Docs](https://docs.example.com)"
+
+# Text + image
+./lark msg send --to oc_xxxx --text "Intro\n{{image}}\nMore details" --image ./diagram.png
+
+# Multiple images
+./lark msg send --to oc_xxxx --text "A\n{{image}}\nB\n{{image}}\nC" --image ./one.png --image ./two.png
+
+# Image only
+./lark msg send --to oc_xxxx --image ./screenshot.png
 ```
 
 Markdown-lite syntax supported:
@@ -378,10 +387,16 @@ Markdown-lite syntax supported:
 - `[text](url)`
 - `@{ou_xxx}` mention placeholders
 
+Image placeholder behavior:
+- Each `{{image}}` consumes the next `--image` in order
+- If there are more placeholders than images, the command fails
+- Extra images are appended after the text, each on its own line
+
 Flags:
 - `--to` (required): Recipient identifier (user ID, open_id, email, or chat_id)
 - `--to-type`: Explicitly specify ID type (`open_id`, `user_id`, `email`, `chat_id`) - auto-detected if omitted
-- `--text` (required): Message text content
+- `--text`: Message text content (markdown-lite). Use `{{image}}` to place images.
+- `--image`: Image file path (repeatable)
 
 Output:
 ```json

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -261,12 +261,12 @@ type OutputError struct {
 
 // OutputAuthStatus is the auth status response for CLI
 type OutputAuthStatus struct {
-	Authenticated bool              `json:"authenticated"`
-	User          string            `json:"user,omitempty"`
-	ExpiresAt     time.Time         `json:"expires_at,omitempty"`
-	RefreshAt     time.Time         `json:"refresh_token_expires_at,omitempty"`
-	GrantedGroups []string          `json:"granted_groups,omitempty"`
-	ScopeGroups   map[string]bool   `json:"scope_groups,omitempty"`
+	Authenticated bool            `json:"authenticated"`
+	User          string          `json:"user,omitempty"`
+	ExpiresAt     time.Time       `json:"expires_at,omitempty"`
+	RefreshAt     time.Time       `json:"refresh_token_expires_at,omitempty"`
+	GrantedGroups []string        `json:"granted_groups,omitempty"`
+	ScopeGroups   map[string]bool `json:"scope_groups,omitempty"`
 }
 
 // OutputSuccess is a generic success response
@@ -1039,6 +1039,14 @@ type SendMessageRequest struct {
 	Content   string `json:"content"`  // JSON string
 }
 
+// UploadImageResponse is the response from POST /im/v1/images
+type UploadImageResponse struct {
+	BaseResponse
+	Data struct {
+		ImageKey string `json:"image_key"`
+	} `json:"data,omitempty"`
+}
+
 // SendMessageResponse is the response from POST /im/v1/messages
 type SendMessageResponse struct {
 	BaseResponse
@@ -1146,9 +1154,9 @@ type OutputMinute struct {
 	Token           string `json:"token"`
 	Title           string `json:"title"`
 	OwnerID         string `json:"owner_id"`
-	CreateTime      string `json:"create_time"`       // ISO 8601 format
-	DurationSeconds int    `json:"duration_seconds"`  // Duration in seconds
-	DurationDisplay string `json:"duration_display"`  // Human-readable duration
+	CreateTime      string `json:"create_time"`      // ISO 8601 format
+	DurationSeconds int    `json:"duration_seconds"` // Duration in seconds
+	DurationDisplay string `json:"duration_display"` // Human-readable duration
 	URL             string `json:"url"`
 }
 
@@ -1211,4 +1219,3 @@ type OutputDocSearchItem struct {
 	Title   string `json:"title"`
 	OwnerID string `json:"owner_id"`
 }
-

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -11,6 +11,7 @@ Retrieve chat message history, send messages, and search for chats/groups via th
 
 **Message Sending Features:**
 - Send markdown-lite text with bold/italic, links, and mentions
+- Send images with `--image` and place `{{image}}` in text to control placement
 - Mention users in group chats with @{open_id}
 - Include clickable links via markdown
 - Send to individual users or group chats
@@ -50,6 +51,11 @@ lark msg send --to oc_12345 --text "**Update:**\n• Task completed\n• Next: *
 **Send with links:**
 ```bash
 lark msg send --to ou_12345 --text "Check this out [Dashboard](https://example.com)"
+```
+
+**Send text + image:**
+```bash
+lark msg send --to oc_12345 --text "Intro\n{{image}}\nMore details" --image ./diagram.png
 ```
 
 **Find chats:**
@@ -150,6 +156,12 @@ lark msg send --to oc_xxxx --text "Please review @{ou_user1} and @{ou_user2}"
 # With link
 lark msg send --to ou_xxxx --text "Check this out [Our Docs](https://docs.example.com)"
 
+# Text + image
+lark msg send --to oc_xxxx --text "Intro\n{{image}}\nMore details" --image ./diagram.png
+
+# Multiple images
+lark msg send --to oc_xxxx --text "A\n{{image}}\nB\n{{image}}\nC" --image ./one.png --image ./two.png
+
 # Combined features
 lark msg send --to oc_xxxx \
   --text "**Project milestone reached!** See [details](https://project.example.com) @{ou_user1} @{ou_user2}"
@@ -161,7 +173,13 @@ lark msg send --to user@example.com --to-type email --text "Hello"
 Available flags:
 - `--to` (required): Recipient identifier (user ID, open_id, email, or chat_id)
 - `--to-type`: Explicitly specify ID type (`open_id`, `user_id`, `email`, `chat_id`) - auto-detected if omitted
-- `--text` (required): Message text content
+- `--text`: Message text content (markdown-lite). Use `{{image}}` to place images.
+- `--image`: Image file path (repeatable)
+
+Image placeholder behavior:
+- Each `{{image}}` consumes the next `--image` in order
+- If there are more placeholders than images, the command fails
+- Extra images are appended after the text, each on its own line
 
 Output:
 ```json
@@ -188,6 +206,7 @@ Output:
 - Use `\t` for indentation: `--text "•\tItem 1\n•\tItem 2"`
 - Use `\"` for quotes: `--text "\"Important:\" message"`
 - Use `\\` for literal backslash: `--text "Path: C:\\\\folder\\\\file"`
+- Place images with `{{image}}`: `--text "Intro\n{{image}}\nMore" --image ./one.png`
 - Use `**bold**` and `*italic*` for emphasis
 - Use `[text](url)` for links
 - Use `@{ou_xxx}` to mention users


### PR DESCRIPTION
- Add image upload API (POST /im/v1/images) with multipart support
- Extend msg send to accept repeated --image flags
- Support {{image}} placeholder in --text to position images inline
- Allow text-image-text combinations within a single post message
- Append extra images after text when placeholders insufficient
- Update documentation with examples and placeholder behavior rules