### PR TITLE
feat: add Lark Sheets support for reading spreadsheets

### DIFF
--- a/internal/api/sheets.go
+++ b/internal/api/sheets.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// GetSpreadsheetSheets retrieves all sheets in a spreadsheet
+// token: the spreadsheet token from the URL
+func (c *Client) GetSpreadsheetSheets(token string) ([]Sheet, error) {
+	path := fmt.Sprintf("/sheets/v3/spreadsheets/%s/sheets/query", url.PathEscape(token))
+
+	var resp SpreadsheetSheetsResponse
+	if err := c.Get(path, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Sheets, nil
+}
+
+// GetSheetMetadata retrieves metadata for a single sheet
+// token: the spreadsheet token
+// sheetID: the sheet ID within the spreadsheet
+func (c *Client) GetSheetMetadata(token, sheetID string) (*Sheet, error) {
+	path := fmt.Sprintf("/sheets/v3/spreadsheets/%s/sheets/%s",
+		url.PathEscape(token), url.PathEscape(sheetID))
+
+	var resp SheetMetadataResponse
+	if err := c.Get(path, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Sheet, nil
+}
+
+// GetSheetData retrieves cell values from a sheet
+// token: the spreadsheet token
+// rangeStr: the range in format "sheetId!A1:Z100" or just "sheetId" for all data
+func (c *Client) GetSheetData(token, rangeStr string) (*SheetValues, error) {
+	path := fmt.Sprintf("/sheets/v2/spreadsheets/%s/values/%s",
+		url.PathEscape(token), url.PathEscape(rangeStr))
+
+	var resp SheetValuesResponse
+	if err := c.Get(path, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1290,3 +1290,92 @@ type OutputDocSearchItem struct {
 	Title   string `json:"title"`
 	OwnerID string `json:"owner_id"`
 }
+
+// --- Spreadsheet/Sheets Types ---
+
+// GridProperties represents the grid dimensions of a sheet
+type GridProperties struct {
+	FrozenRowCount    int `json:"frozen_row_count,omitempty"`
+	FrozenColumnCount int `json:"frozen_column_count,omitempty"`
+	RowCount          int `json:"row_count,omitempty"`
+	ColumnCount       int `json:"column_count,omitempty"`
+}
+
+// Sheet represents a sheet within a spreadsheet
+type Sheet struct {
+	SheetID        string          `json:"sheet_id"`
+	Title          string          `json:"title"`
+	Index          int             `json:"index"`
+	Hidden         bool            `json:"hidden,omitempty"`
+	GridProperties *GridProperties `json:"grid_properties,omitempty"`
+	ResourceType   string          `json:"resource_type,omitempty"`
+}
+
+// SheetValues represents cell data from a sheet
+type SheetValues struct {
+	Revision         int         `json:"revision,omitempty"`
+	SpreadsheetToken string      `json:"spreadsheetToken,omitempty"`
+	Range            string      `json:"range,omitempty"`
+	ValueRange       *ValueRange `json:"valueRange,omitempty"`
+}
+
+// ValueRange represents a range of cell values
+type ValueRange struct {
+	MajorDimension string      `json:"majorDimension,omitempty"`
+	Range          string      `json:"range,omitempty"`
+	Revision       int         `json:"revision,omitempty"`
+	Values         [][]any     `json:"values,omitempty"`
+}
+
+// --- Spreadsheet API Response Types ---
+
+// SpreadsheetSheetsResponse is the response from GET /sheets/v3/spreadsheets/:token/sheets/query
+type SpreadsheetSheetsResponse struct {
+	BaseResponse
+	Data struct {
+		Sheets []Sheet `json:"sheets,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// SheetMetadataResponse is the response from GET /sheets/v3/spreadsheets/:token/sheets/:sheet_id
+type SheetMetadataResponse struct {
+	BaseResponse
+	Data struct {
+		Sheet *Sheet `json:"sheet,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// SheetValuesResponse is the response from GET /sheets/v2/spreadsheets/:token/values/:range
+type SheetValuesResponse struct {
+	BaseResponse
+	Data *SheetValues `json:"data,omitempty"`
+}
+
+// --- Spreadsheet CLI Output Types ---
+
+// OutputSheetList is the list sheets response for CLI
+type OutputSheetList struct {
+	SpreadsheetToken string        `json:"spreadsheet_token"`
+	Sheets           []OutputSheet `json:"sheets"`
+	Count            int           `json:"count"`
+}
+
+// OutputSheet is the simplified sheet format for CLI output
+type OutputSheet struct {
+	SheetID     string `json:"sheet_id"`
+	Title       string `json:"title"`
+	Index       int    `json:"index"`
+	Hidden      bool   `json:"hidden,omitempty"`
+	RowCount    int    `json:"row_count,omitempty"`
+	ColumnCount int    `json:"column_count,omitempty"`
+}
+
+// OutputSheetData is the sheet data response for CLI
+type OutputSheetData struct {
+	SpreadsheetToken string  `json:"spreadsheet_token"`
+	SheetID          string  `json:"sheet_id"`
+	Range            string  `json:"range"`
+	RowCount         int     `json:"row_count"`
+	ColumnCount      int     `json:"column_count"`
+	Values           [][]any `json:"values"`
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -70,5 +70,6 @@ func init() {
 	rootCmd.AddCommand(mailCmd)
 	rootCmd.AddCommand(minutesCmd)
 	rootCmd.AddCommand(msgCmd)
+	rootCmd.AddCommand(sheetCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/cmd/sheet.go
+++ b/internal/cmd/sheet.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/yjwong/lark-cli/internal/api"
+	"github.com/yjwong/lark-cli/internal/output"
+)
+
+var sheetCmd = &cobra.Command{
+	Use:   "sheet",
+	Short: "Spreadsheet commands",
+	Long:  "Read and query Lark Sheets (spreadsheets)",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		validateScopeGroup("documents")
+	},
+}
+
+// --- sheet list ---
+
+var sheetListCmd = &cobra.Command{
+	Use:   "list <spreadsheet_token>",
+	Short: "List all sheets in a spreadsheet",
+	Long: `List all sheets (tabs) within a Lark spreadsheet.
+
+The spreadsheet_token is from the spreadsheet URL.
+For example, if the URL is https://xxx.larksuite.com/sheets/T4mHsrFyzhXrj0tVzRslUGx8gkA
+then the spreadsheet_token is T4mHsrFyzhXrj0tVzRslUGx8gkA.
+
+Examples:
+  lark sheet list T4mHsrFyzhXrj0tVzRslUGx8gkA`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		token := args[0]
+
+		client := api.NewClient()
+
+		sheets, err := client.GetSpreadsheetSheets(token)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		outputSheets := make([]api.OutputSheet, len(sheets))
+		for i, s := range sheets {
+			outputSheets[i] = api.OutputSheet{
+				SheetID: s.SheetID,
+				Title:   s.Title,
+				Index:   s.Index,
+				Hidden:  s.Hidden,
+			}
+			if s.GridProperties != nil {
+				outputSheets[i].RowCount = s.GridProperties.RowCount
+				outputSheets[i].ColumnCount = s.GridProperties.ColumnCount
+			}
+		}
+
+		result := api.OutputSheetList{
+			SpreadsheetToken: token,
+			Sheets:           outputSheets,
+			Count:            len(outputSheets),
+		}
+
+		output.JSON(result)
+	},
+}
+
+// --- sheet read ---
+
+var sheetReadCmd = &cobra.Command{
+	Use:   "read <spreadsheet_token>",
+	Short: "Read cell data from a sheet",
+	Long: `Read cell values from a Lark spreadsheet.
+
+By default, reads the first sheet (index 0) and up to 1000 rows.
+Use --sheet to specify a sheet ID, and --range to specify a cell range.
+
+The spreadsheet_token is from the spreadsheet URL.
+For example, if the URL is https://xxx.larksuite.com/sheets/T4mHsrFyzhXrj0tVzRslUGx8gkA
+then the spreadsheet_token is T4mHsrFyzhXrj0tVzRslUGx8gkA.
+
+Range format: A1:Z100 (columns A-Z, rows 1-100)
+If no range is specified, reads from A1 up to the sheet's actual dimensions (max 1000 rows).
+
+Examples:
+  lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA
+  lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123
+  lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --range A1:D50
+  lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123 --range A1:Z100`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		token := args[0]
+		sheetID, _ := cmd.Flags().GetString("sheet")
+		rangeSpec, _ := cmd.Flags().GetString("range")
+
+		client := api.NewClient()
+
+		// If no sheet ID specified, get the first sheet
+		if sheetID == "" {
+			sheets, err := client.GetSpreadsheetSheets(token)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+			if len(sheets) == 0 {
+				output.Fatal("NO_SHEETS", fmt.Errorf("spreadsheet has no sheets"))
+			}
+			// Find the sheet with the lowest index (first sheet)
+			firstSheet := sheets[0]
+			for _, s := range sheets[1:] {
+				if s.Index < firstSheet.Index {
+					firstSheet = s
+				}
+			}
+			sheetID = firstSheet.SheetID
+		}
+
+		// Build the range string
+		var fullRange string
+		if rangeSpec != "" {
+			fullRange = sheetID + "!" + rangeSpec
+		} else {
+			// Default: read up to 1000 rows, determined by sheet size
+			// Get sheet metadata to determine actual dimensions
+			sheet, err := client.GetSheetMetadata(token, sheetID)
+			if err != nil {
+				// Fall back to a reasonable default if we can't get metadata
+				fullRange = sheetID + "!A1:Z1000"
+			} else if sheet.GridProperties != nil {
+				rowCount := sheet.GridProperties.RowCount
+				colCount := sheet.GridProperties.ColumnCount
+				if rowCount > 1000 {
+					rowCount = 1000
+				}
+				if colCount > 26 {
+					colCount = 26 // Limit to column Z for simplicity
+				}
+				endCol := columnIndexToLetter(colCount)
+				fullRange = fmt.Sprintf("%s!A1:%s%d", sheetID, endCol, rowCount)
+			} else {
+				fullRange = sheetID + "!A1:Z1000"
+			}
+		}
+
+		// Get the data
+		data, err := client.GetSheetData(token, fullRange)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		// Extract values from response
+		var values [][]any
+		var actualRange string
+		if data.ValueRange != nil {
+			values = data.ValueRange.Values
+			actualRange = data.ValueRange.Range
+		}
+
+		// Calculate dimensions
+		rowCount := len(values)
+		colCount := 0
+		for _, row := range values {
+			if len(row) > colCount {
+				colCount = len(row)
+			}
+		}
+
+		result := api.OutputSheetData{
+			SpreadsheetToken: token,
+			SheetID:          sheetID,
+			Range:            actualRange,
+			RowCount:         rowCount,
+			ColumnCount:      colCount,
+			Values:           values,
+		}
+
+		output.JSON(result)
+	},
+}
+
+// columnIndexToLetter converts a 1-based column index to a letter (1=A, 26=Z)
+func columnIndexToLetter(index int) string {
+	if index <= 0 {
+		return "A"
+	}
+	if index > 26 {
+		index = 26
+	}
+	return string(rune('A' + index - 1))
+}
+
+func init() {
+	// Register subcommands
+	sheetCmd.AddCommand(sheetListCmd)
+	sheetCmd.AddCommand(sheetReadCmd)
+
+	// Flags for sheet read
+	sheetReadCmd.Flags().String("sheet", "", "Sheet ID to read from (default: first sheet)")
+	sheetReadCmd.Flags().String("range", "", "Cell range to read (e.g., A1:Z100)")
+}

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -14,7 +14,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark doc <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark doc <command>
+LARK_CONFIG_DIR=/Users/yingcong/Code/lark-cli/.lark lark doc <command>
 ```
 
 ## Commands Reference
@@ -241,12 +241,69 @@ Fields:
 - `is_solved`: whether the comment thread has been resolved
 - `quote`: the highlighted text from the document (for inline comments)
 
+## Spreadsheet Commands
+
+### List Sheets in a Spreadsheet
+
+```bash
+lark sheet list <spreadsheet_token>
+```
+
+Lists all sheets (tabs) within a Lark spreadsheet.
+
+Output:
+```json
+{
+  "spreadsheet_token": "T4mHsrFyzhXrj0tVzRslUGx8gkA",
+  "sheets": [
+    {
+      "sheet_id": "abc123",
+      "title": "Sheet1",
+      "index": 0,
+      "row_count": 100,
+      "column_count": 10
+    }
+  ],
+  "count": 1
+}
+```
+
+### Read Sheet Data
+
+```bash
+lark sheet read <spreadsheet_token> [--sheet <sheet_id>] [--range A1:Z100]
+```
+
+Reads cell values from a Lark spreadsheet.
+
+Options:
+- `--sheet`: Sheet ID to read from (default: first sheet by index)
+- `--range`: Cell range to read (e.g., `A1:Z100`). Default: all data up to 1000 rows
+
+Output:
+```json
+{
+  "spreadsheet_token": "T4mHsrFyzhXrj0tVzRslUGx8gkA",
+  "sheet_id": "abc123",
+  "range": "abc123!A1:D10",
+  "row_count": 10,
+  "column_count": 4,
+  "values": [
+    ["Header1", "Header2", "Header3", "Header4"],
+    ["Value1", "Value2", 123, true]
+  ]
+}
+```
+
+**Note:** Cell values preserve their types (string, number, boolean). Empty cells may be omitted from rows.
+
 ## Extracting IDs from URLs
 
-| URL Type | Example | How to Get Document Content |
+| URL Type | Example | How to Get Content |
 |----------|---------|----------------------------|
 | Direct doc | `https://xxx.larksuite.com/docx/ABC123xyz` | Use `ABC123xyz` directly with `doc get` |
 | Wiki | `https://xxx.larksuite.com/wiki/X8Tawq43...` | First run `doc wiki X8Tawq43...` to get `obj_token`, then use that with `doc get` |
+| Spreadsheet | `https://xxx.larksuite.com/sheets/T4mHsr...` | Use `T4mHsr...` with `sheet list` or `sheet read` |
 
 **Important**: Wiki URLs require a two-step process - resolve the node first, then fetch the document.
 
@@ -264,6 +321,8 @@ Fields:
 | Search for text | `doc get` | Grep-able markdown |
 | Count elements | `doc blocks` | Block types enumerated |
 | Read comments/feedback | `doc comments` | Get all comments and replies |
+| List sheets in spreadsheet | `sheet list` | See all tabs and their sizes |
+| Read spreadsheet data | `sheet read` | Get cell values as JSON |
 
 **Default to `doc get`** - it's 2-3x smaller and sufficient for most tasks.
 

--- a/skills/sheets/SKILL.md
+++ b/skills/sheets/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: sheets
+description: Read and query Lark Sheets (spreadsheets) - list sheets in a spreadsheet, read cell data. Use when user asks about a spreadsheet, wants to read data from a Lark sheet, or mentions a spreadsheet URL/ID.
+---
+
+# Lark Sheets Skill
+
+Read and query Lark Sheets (spreadsheets) via the `lark` CLI.
+
+## Running Commands
+
+Ensure `lark` is in your PATH, or use the full path to the binary. Set the config directory if not using the default:
+
+```bash
+lark sheet <command>
+# Or with explicit config:
+LARK_CONFIG_DIR=/Users/yingcong/Code/lark-cli/.lark lark sheet <command>
+```
+
+## Commands Reference
+
+### List Sheets in a Spreadsheet
+
+```bash
+lark sheet list <spreadsheet_token>
+```
+
+Lists all sheets (tabs) within a Lark spreadsheet. Returns sheet IDs, titles, dimensions, and hidden status.
+
+Output:
+```json
+{
+  "spreadsheet_token": "T4mHsrFyzhXrj0tVzRslUGx8gkA",
+  "sheets": [
+    {
+      "sheet_id": "abc123",
+      "title": "Sheet1",
+      "index": 0,
+      "row_count": 100,
+      "column_count": 10
+    },
+    {
+      "sheet_id": "def456",
+      "title": "Sheet2",
+      "index": 1,
+      "hidden": true,
+      "row_count": 50,
+      "column_count": 5
+    }
+  ],
+  "count": 2
+}
+```
+
+Fields:
+- `sheet_id`: The unique ID of the sheet (use this with `--sheet` flag)
+- `title`: Display name of the sheet
+- `index`: Position of the sheet (0-indexed)
+- `hidden`: Whether the sheet is hidden in the UI
+- `row_count` / `column_count`: Dimensions of the sheet
+
+### Read Sheet Data
+
+```bash
+lark sheet read <spreadsheet_token> [--sheet <sheet_id>] [--range A1:Z100]
+```
+
+Reads cell values from a Lark spreadsheet.
+
+Options:
+- `--sheet`: Sheet ID to read from (default: first sheet by index)
+- `--range`: Cell range to read (e.g., `A1:Z100`). Default: all data up to 1000 rows
+
+Output:
+```json
+{
+  "spreadsheet_token": "T4mHsrFyzhXrj0tVzRslUGx8gkA",
+  "sheet_id": "abc123",
+  "range": "abc123!A1:D10",
+  "row_count": 10,
+  "column_count": 4,
+  "values": [
+    ["Header1", "Header2", "Header3", "Header4"],
+    ["Value1", "Value2", 123, true],
+    ["Row2Val1", null, 456, false]
+  ]
+}
+```
+
+**Note:** Cell values preserve their types (string, number, boolean). Empty cells may appear as `null` or be omitted from rows. Some cells with rich formatting may return structured objects instead of plain values.
+
+## Extracting IDs from URLs
+
+The spreadsheet_token is from the spreadsheet URL:
+- URL: `https://xxx.larksuite.com/sheets/T4mHsrFyzhXrj0tVzRslUGx8gkA`
+- Token: `T4mHsrFyzhXrj0tVzRslUGx8gkA`
+
+## Which Command to Use
+
+| Use Case | Command | Notes |
+|----------|---------|-------|
+| Browse sheets/tabs | `sheet list` | See all sheets and dimensions |
+| Read specific data | `sheet read --range` | Target specific cells |
+| Read full sheet | `sheet read --sheet` | Up to 1000 rows |
+| Read first sheet | `sheet read` | Auto-selects first by index |
+
+## Workflow Examples
+
+### Get Overview of a Spreadsheet
+
+```bash
+# List all sheets first
+lark sheet list T4mHsrFyzhXrj0tVzRslUGx8gkA
+
+# Then read specific sheet
+lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123 --range A1:D20
+```
+
+### Read Header Row Only
+
+```bash
+lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --range A1:Z1
+```
+
+### Read First 50 Rows of Specific Sheet
+
+```bash
+lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet def456 --range A1:Z50
+```
+
+## Efficient Extraction with jq
+
+For large spreadsheets, use `jq` to extract specific data without loading everything into context.
+
+### Get Column Headers
+
+```bash
+lark sheet read <token> --range A1:Z1 | jq '.values[0]'
+```
+
+### Get Row Count
+
+```bash
+lark sheet read <token> | jq '.row_count'
+```
+
+### Extract Specific Column (Column B)
+
+```bash
+lark sheet read <token> | jq '[.values[] | .[1]]'
+```
+
+### Find Rows Matching a Value
+
+```bash
+lark sheet read <token> | jq '[.values[] | select(.[0] == "SearchValue")]'
+```
+
+### Get First N Rows
+
+```bash
+lark sheet read <token> | jq '.values[:10]'
+```
+
+## Output Format
+
+All commands output JSON. Format appropriately when presenting to user.
+
+## Error Handling
+
+Errors return JSON:
+```json
+{
+  "error": true,
+  "code": "ERROR_CODE",
+  "message": "Description"
+}
+```
+
+Common error codes:
+- `AUTH_ERROR` - Need to run `lark auth login`
+- `SCOPE_ERROR` - Missing documents permissions. Run `lark auth login --add --scopes documents`
+- `API_ERROR` - Lark API issue (often permissions)
+- `NO_SHEETS` - Spreadsheet has no sheets
+
+## Required Permissions
+
+This skill requires the `documents` scope group (uses `drive:drive:readonly`). If you see a `SCOPE_ERROR`, the user needs to add documents permissions:
+
+```bash
+lark auth login --add --scopes documents
+```
+
+To check current permissions:
+```bash
+lark auth status
+```
+
+## Limitations
+
+- Maximum 1000 rows read by default (use `--range` for specific cells)
+- Column letters limited to A-Z (26 columns) when auto-detecting range
+- Rich text cells may return structured objects instead of plain strings
+- Some merged cells may have unexpected value placement


### PR DESCRIPTION
## Summary
- Add new `lark sheet` commands for reading Lark Sheets (spreadsheets)
- `sheet list <token>` - List all sheets/tabs in a spreadsheet with dimensions and hidden status
- `sheet read <token>` - Read cell data with optional `--sheet` and `--range` flags
- Uses existing `drive:drive:readonly` scope, no new OAuth setup needed

## Changes
**New files:**
- `internal/api/sheets.go` - API client methods (GetSpreadsheetSheets, GetSheetMetadata, GetSheetData)
- `internal/cmd/sheet.go` - Cobra commands (sheet list, sheet read)
- `skills/sheets/SKILL.md` - Sheets skill documentation

**Updated files:**
- `internal/api/types.go` - Sheet, GridProperties, SheetValues types
- `internal/cmd/root.go` - Register sheetCmd
- `skills/documents/SKILL.md` - Added spreadsheet section

## Test plan
- [x] `make build` succeeds
- [x] `lark sheet list T4mHsrFyzhXrj0tVzRslUGx8gkA` returns sheets with metadata
- [x] `lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --range A1:C10` returns cell values
- [ ] Verify with additional spreadsheets

cc @yjwong

🤖 Generated with [Claude Code](https://claude.com/claude-code)