### PR TITLE
feat: add Drive file download command

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -186,6 +186,22 @@ func (c *Client) DownloadMedia(fileToken, documentID string) (io.ReadCloser, str
 	return c.Download(path)
 }
 
+// DownloadDriveFile downloads a file from Lark Drive
+// fileToken: the file token from doc list or search
+// Returns the file content as a ReadCloser and the content type
+func (c *Client) DownloadDriveFile(fileToken string) (io.ReadCloser, string, error) {
+	path := fmt.Sprintf("/drive/v1/files/%s/download", url.PathEscape(fileToken))
+	// Try user token first, if that fails it might be a permission issue
+	return c.Download(path)
+}
+
+// DownloadDriveFileWithTenant downloads a file using tenant token
+// This may be needed for files shared with the bot
+func (c *Client) DownloadDriveFileWithTenant(fileToken string) (io.ReadCloser, string, error) {
+	path := fmt.Sprintf("/drive/v1/files/%s/download", url.PathEscape(fileToken))
+	return c.DownloadWithTenantToken(path)
+}
+
 // SearchDocuments searches for documents using the Lark Docs API
 // query: search keyword (required)
 // ownerIDs: optional filter by owner user IDs

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -80,6 +80,29 @@ Item types: `doc`, `docx`, `sheet`, `bitable`, `mindnote`, `file`, `folder`, `sh
 
 For shortcuts, includes `shortcut_info` with `target_type` and `target_token`.
 
+### Download File from Drive
+
+```bash
+lark doc download <file_token> -o <output_path>
+```
+
+Downloads a file from Lark Drive. The file token is obtained from `doc list` or `doc search` output. Only files with type "file" can be downloaded (not docs, sheets, etc - those are Lark native formats).
+
+Options:
+- `-o, --output`: Output file path (required)
+
+Output:
+```json
+{
+  "file_token": "FG3obxWuaoftXIx0CvxlQAabcef",
+  "filename": "report.pdf",
+  "content_type": "application/pdf",
+  "size": 1048576
+}
+```
+
+**Note:** You must have read access to the file. If you get a 403 error, the file may not be shared with you.
+
 ### Resolve Wiki Node to Document ID
 
 ```bash
@@ -314,6 +337,7 @@ Output:
 | Search for documents | `doc search` | Find docs by keyword across Drive |
 | Search wiki by keyword | `doc wiki-search` | Find wiki nodes by keyword |
 | List folder contents | `doc list [folder-token]` | Browse Drive files and folders |
+| Download a file | `doc download` | Save Drive files locally |
 | Wiki URL | `doc wiki` then `doc get` | Must resolve wiki node first |
 | List wiki sub-pages | `doc wiki-children` | Browse wiki hierarchy |
 | Read/summarize content | `doc get` | Markdown is compact (~90KB) |


### PR DESCRIPTION
## Summary
- Add `doc download` command to download files from Lark Drive
- Files must be of type "file" (uploaded files like PDFs, images, etc)
- Adds DownloadDriveFile API method
- Updates SKILL.md documentation

## Usage
```bash
lark doc download <file_token> -o <output_path>
```

## Test plan
- [ ] Search for a file: `lark doc search "pdf" --type file`
- [ ] Download a file you have access to: `lark doc download <token> -o test.pdf`
- [ ] Verify the file is downloaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)