### PR TITLE
feat: add Lark Tasks support

### DIFF
--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// TaskListOptions configures the list tasks request
+type TaskListOptions struct {
+	PageSize  int    // Tasks per page (max 100)
+	PageToken string // Pagination token
+	Completed bool   // Include completed tasks
+}
+
+// ListTasks lists tasks for the current user
+func (c *Client) ListTasks(opts *TaskListOptions) ([]Task, bool, string, error) {
+	pageSize := 50
+	if opts != nil && opts.PageSize > 0 {
+		pageSize = opts.PageSize
+		if pageSize > 100 {
+			pageSize = 100
+		}
+	}
+
+	params := url.Values{}
+	params.Set("page_size", strconv.Itoa(pageSize))
+	params.Set("user_id_type", "open_id")
+
+	if opts != nil {
+		if opts.PageToken != "" {
+			params.Set("page_token", opts.PageToken)
+		}
+		if opts.Completed {
+			params.Set("completed", "true")
+		}
+	}
+
+	path := "/task/v2/tasks?" + params.Encode()
+
+	var resp TaskListResponse
+	if err := c.Get(path, &resp); err != nil {
+		return nil, false, "", err
+	}
+
+	if resp.Code != 0 {
+		return nil, false, "", fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Items, resp.Data.HasMore, resp.Data.PageToken, nil
+}
+
+// GetTask retrieves a single task by GUID
+func (c *Client) GetTask(taskGUID string) (*Task, error) {
+	params := url.Values{}
+	params.Set("user_id_type", "open_id")
+
+	path := fmt.Sprintf("/task/v2/tasks/%s?%s", url.PathEscape(taskGUID), params.Encode())
+
+	var resp TaskResponse
+	if err := c.Get(path, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Task, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1388,6 +1388,79 @@ type OutputSheetData struct {
 	Values           [][]any `json:"values"`
 }
 
+// --- Task Types ---
+
+// Task represents a Lark task
+type Task struct {
+	GUID        string       `json:"guid,omitempty"`
+	Summary     string       `json:"summary,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Due         *TaskDue     `json:"due,omitempty"`
+	Creator     *TaskMember  `json:"creator,omitempty"`
+	Members     []TaskMember `json:"members,omitempty"`
+	CompletedAt string       `json:"completed_at,omitempty"`
+	CreatedAt   string       `json:"created_at,omitempty"`
+	UpdatedAt   string       `json:"updated_at,omitempty"`
+	Status      string       `json:"status,omitempty"`
+	Mode        int          `json:"mode,omitempty"`
+	Source      int          `json:"source,omitempty"`
+}
+
+// TaskDue represents a task due date
+type TaskDue struct {
+	Timestamp string `json:"timestamp,omitempty"`
+	IsAllDay  bool   `json:"is_all_day,omitempty"`
+}
+
+// TaskMember represents a task member (creator, assignee, etc.)
+type TaskMember struct {
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+	Role string `json:"role,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// TaskListResponse is the API response for listing tasks
+type TaskListResponse struct {
+	BaseResponse
+	Data struct {
+		HasMore   bool   `json:"has_more"`
+		PageToken string `json:"page_token,omitempty"`
+		Items     []Task `json:"items,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// TaskResponse is the API response for getting a single task
+type TaskResponse struct {
+	BaseResponse
+	Data struct {
+		Task *Task `json:"task,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// --- Task CLI Output Types ---
+
+// OutputTaskList is the list tasks response for CLI
+type OutputTaskList struct {
+	Tasks   []OutputTask `json:"tasks"`
+	Count   int          `json:"count"`
+	HasMore bool         `json:"has_more"`
+}
+
+// OutputTask is the simplified task format for CLI output
+type OutputTask struct {
+	GUID        string `json:"guid"`
+	Summary     string `json:"summary"`
+	Description string `json:"description,omitempty"`
+	DueDate     string `json:"due_date,omitempty"`
+	IsAllDay    bool   `json:"is_all_day,omitempty"`
+	Status      string `json:"status"`
+	CreatorID   string `json:"creator_id,omitempty"`
+	CreatorName string `json:"creator_name,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+}
+
 // --- Bitable Types ---
 
 // BitableTable represents a table in a Bitable app

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,5 +72,6 @@ func init() {
 	rootCmd.AddCommand(minutesCmd)
 	rootCmd.AddCommand(msgCmd)
 	rootCmd.AddCommand(sheetCmd)
+	rootCmd.AddCommand(taskCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/yjwong/lark-cli/internal/api"
+	"github.com/yjwong/lark-cli/internal/output"
+)
+
+var taskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "Task commands",
+	Long:  "View and manage Lark Tasks",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		validateScopeGroup("tasks")
+	},
+}
+
+// --- task list ---
+
+var (
+	taskListLimit     int
+	taskListCompleted bool
+)
+
+var taskListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List tasks",
+	Long: `List tasks assigned to you.
+
+By default, only shows incomplete tasks. Use --completed to include completed tasks.
+
+Examples:
+  lark task list
+  lark task list --limit 50
+  lark task list --completed`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewClient()
+
+		opts := &api.TaskListOptions{
+			PageSize:  50,
+			Completed: taskListCompleted,
+		}
+
+		var allTasks []api.Task
+		var pageToken string
+		hasMore := true
+		remaining := taskListLimit
+
+		for hasMore {
+			if remaining > 0 && remaining < opts.PageSize {
+				opts.PageSize = remaining
+			}
+			opts.PageToken = pageToken
+
+			tasks, more, nextToken, err := client.ListTasks(opts)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+
+			allTasks = append(allTasks, tasks...)
+			hasMore = more
+			pageToken = nextToken
+
+			if taskListLimit > 0 {
+				remaining = taskListLimit - len(allTasks)
+				if remaining <= 0 {
+					break
+				}
+			}
+		}
+
+		// Trim to limit if needed
+		if taskListLimit > 0 && len(allTasks) > taskListLimit {
+			allTasks = allTasks[:taskListLimit]
+		}
+
+		outputTasks := make([]api.OutputTask, len(allTasks))
+		for i, t := range allTasks {
+			outputTasks[i] = taskToOutput(t)
+		}
+
+		result := api.OutputTaskList{
+			Tasks:   outputTasks,
+			Count:   len(outputTasks),
+			HasMore: hasMore,
+		}
+
+		output.JSON(result)
+	},
+}
+
+// --- task get ---
+
+var taskGetCmd = &cobra.Command{
+	Use:   "get <task_guid>",
+	Short: "Get task details",
+	Long: `Get details of a specific task by its GUID.
+
+The task GUID is returned in the list command output.
+
+Examples:
+  lark task get d300e75f-c56a-4be9-80d6-e47653b3e1a9`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		taskGUID := args[0]
+
+		client := api.NewClient()
+
+		task, err := client.GetTask(taskGUID)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		if task == nil {
+			output.Fatalf("NOT_FOUND", "Task not found: %s", taskGUID)
+		}
+
+		result := taskToOutput(*task)
+		output.JSON(result)
+	},
+}
+
+// taskToOutput converts a Task to OutputTask
+func taskToOutput(t api.Task) api.OutputTask {
+	out := api.OutputTask{
+		GUID:        t.GUID,
+		Summary:     t.Summary,
+		Description: t.Description,
+		Status:      taskStatusToString(t.Status),
+		CompletedAt: t.CompletedAt,
+		CreatedAt:   t.CreatedAt,
+	}
+
+	if t.Due != nil {
+		out.DueDate = formatTaskTimestamp(t.Due.Timestamp)
+		out.IsAllDay = t.Due.IsAllDay
+	}
+
+	if t.Creator != nil {
+		out.CreatorID = t.Creator.ID
+		out.CreatorName = t.Creator.Name
+	}
+
+	return out
+}
+
+// taskStatusToString converts task status to human-readable string
+func taskStatusToString(status string) string {
+	switch status {
+	case "todo":
+		return "todo"
+	case "done":
+		return "completed"
+	default:
+		return status
+	}
+}
+
+// formatTaskTimestamp formats a task timestamp (Unix ms) to RFC3339
+func formatTaskTimestamp(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	// Task API returns timestamps as strings (Unix ms)
+	var msec int64
+	if _, err := time.Parse(time.RFC3339, ts); err == nil {
+		// Already in RFC3339 format
+		return ts
+	}
+	// Try parsing as Unix milliseconds
+	if n, err := time.Parse("2006-01-02", ts); err == nil {
+		return n.Format("2006-01-02")
+	}
+	// Try parsing as integer milliseconds
+	for i := 0; i < len(ts); i++ {
+		if ts[i] >= '0' && ts[i] <= '9' {
+			msec = msec*10 + int64(ts[i]-'0')
+		} else {
+			return ts // Return as-is if can't parse
+		}
+	}
+	if msec > 0 {
+		return time.UnixMilli(msec).Format(time.RFC3339)
+	}
+	return ts
+}
+
+func init() {
+	// task list flags
+	taskListCmd.Flags().IntVar(&taskListLimit, "limit", 0,
+		"Maximum number of tasks to retrieve (0 = no limit)")
+	taskListCmd.Flags().BoolVar(&taskListCompleted, "completed", false,
+		"Include completed tasks")
+
+	// Register subcommands
+	taskCmd.AddCommand(taskListCmd)
+	taskCmd.AddCommand(taskGetCmd)
+}

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -57,11 +57,17 @@ var Groups = map[string]ScopeGroup{
 		Scopes:      []string{"minutes:minutes:readonly", "minutes:minute:download"},
 		Commands:    []string{"minutes"},
 	},
+	"tasks": {
+		Name:        "tasks",
+		Description: "Lark Tasks management",
+		Scopes:      []string{"task:task:read"},
+		Commands:    []string{"task"},
+	},
 }
 
 // AllGroupNames returns all scope group names in a consistent order
 func AllGroupNames() []string {
-	return []string{"calendar", "contacts", "documents", "bitable", "messages", "mail", "minutes"}
+	return []string{"calendar", "contacts", "documents", "bitable", "messages", "mail", "minutes", "tasks"}
 }
 
 // GetScopesForGroups returns the combined scopes for the given group names

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: tasks
+description: View Lark Tasks - list your tasks and view task details. Use when user asks about their todo list, tasks, or things to do.
+---
+
+# Lark Tasks Skill
+
+View Lark Tasks via the `lark` CLI.
+
+## Running Commands
+
+Ensure `lark` is in your PATH, or use the full path to the binary:
+
+```bash
+lark task <command>
+```
+
+## Commands Reference
+
+### List Tasks
+
+```bash
+lark task list [--limit N] [--completed]
+```
+
+Lists tasks assigned to you. By default, only shows incomplete tasks.
+
+Options:
+- `--limit`: Maximum number of tasks to retrieve (default: no limit)
+- `--completed`: Include completed tasks
+
+Output:
+```json
+{
+  "tasks": [
+    {
+      "guid": "d300e75f-c56a-4be9-80d6-e47653b3e1a9",
+      "summary": "Review Q4 budget proposal",
+      "description": "Check the numbers and approve",
+      "due_date": "2026-02-05T00:00:00+08:00",
+      "is_all_day": true,
+      "status": "todo",
+      "creator_id": "ou_xxx",
+      "creator_name": "John Doe",
+      "created_at": "1704067200000"
+    }
+  ],
+  "count": 1,
+  "has_more": false
+}
+```
+
+### Get Task Details
+
+```bash
+lark task get <task_guid>
+```
+
+Gets details of a specific task by its GUID.
+
+Output:
+```json
+{
+  "guid": "d300e75f-c56a-4be9-80d6-e47653b3e1a9",
+  "summary": "Review Q4 budget proposal",
+  "description": "Check the numbers and approve by EOD",
+  "due_date": "2026-02-05T00:00:00+08:00",
+  "is_all_day": true,
+  "status": "todo",
+  "creator_id": "ou_xxx",
+  "creator_name": "John Doe",
+  "created_at": "1704067200000"
+}
+```
+
+## Task Status Values
+
+| Status | Description |
+|--------|-------------|
+| `todo` | Task is incomplete |
+| `completed` | Task has been completed |
+
+## Error Handling
+
+Errors return JSON:
+```json
+{
+  "error": true,
+  "code": "ERROR_CODE",
+  "message": "Description"
+}
+```
+
+Common error codes:
+- `AUTH_ERROR` - Need to run `lark auth login`
+- `SCOPE_ERROR` - Missing tasks permissions. Run `lark auth login --add --scopes tasks`
+- `NOT_FOUND` - Task GUID not found
+- `API_ERROR` - Lark API issue
+
+## Required Permissions
+
+This skill requires the `tasks` scope group. If you see a `SCOPE_ERROR`, add the permissions:
+
+```bash
+lark auth login --add --scopes tasks
+```
+
+To check current permissions:
+```bash
+lark auth status
+```
+
+## Best Practices
+
+### Daily Task Review
+```bash
+# Show all incomplete tasks
+lark task list
+
+# Show including completed
+lark task list --completed --limit 20
+```
+
+### Integration with Calendar
+Tasks with due dates can be cross-referenced with calendar events to help plan the day.
+
+### Working with Task Details
+- Use `task get` to see the full description
+- Creator information helps identify who assigned the task
+- Check `due_date` and `is_all_day` for deadline information


### PR DESCRIPTION
## Summary
- Add task command with subcommands for viewing Lark Tasks
- task list - list tasks assigned to user with pagination
- task get - get details of a specific task

## New Scope Group
Requires new tasks scope group:
- task:task:read

## Test plan
- Add tasks scope: lark auth login --add --scopes tasks
- List tasks: lark task list
- Get task details: lark task get <guid>

Generated with Claude Code