### PR TITLE
feat: add sheet write command

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -95,6 +95,11 @@ func (c *Client) Patch(path string, body interface{}, result interface{}) error 
 	return c.doRequest("PATCH", path, body, result)
 }
 
+// Put performs a PUT request
+func (c *Client) Put(path string, body interface{}, result interface{}) error {
+	return c.doRequest("PUT", path, body, result)
+}
+
 // Delete performs a DELETE request
 func (c *Client) Delete(path string, result interface{}) error {
 	return c.doRequest("DELETE", path, nil, result)

--- a/internal/api/sheets.go
+++ b/internal/api/sheets.go
@@ -59,3 +59,29 @@ func (c *Client) GetSheetData(token, rangeStr string) (*SheetValues, error) {
 
 	return resp.Data, nil
 }
+
+// SetSheetData writes cell values to a sheet
+// token: the spreadsheet token
+// sheetRange: the range in format "sheetId!A1:C3"
+// values: 2D array of values to write
+func (c *Client) SetSheetData(token string, sheetRange string, values [][]any) (*SetSheetValuesData, error) {
+	path := fmt.Sprintf("/sheets/v2/spreadsheets/%s/values", url.PathEscape(token))
+
+	req := SetSheetValuesRequest{
+		ValueRange: ValueRange{
+			Range:  sheetRange,
+			Values: values,
+		},
+	}
+
+	var resp SetSheetValuesResponse
+	if err := c.Put(path, req, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1388,6 +1388,40 @@ type OutputSheetData struct {
 	Values           [][]any `json:"values"`
 }
 
+// --- Spreadsheet Write Types ---
+
+// SetSheetValuesRequest is the request body for PUT /sheets/v2/spreadsheets/:token/values
+type SetSheetValuesRequest struct {
+	ValueRange ValueRange `json:"valueRange"`
+}
+
+// SetSheetValuesData is the response data from setting sheet values
+type SetSheetValuesData struct {
+	SpreadsheetToken string `json:"spreadsheetToken,omitempty"`
+	UpdatedRange     string `json:"updatedRange,omitempty"`
+	UpdatedRows      int    `json:"updatedRows,omitempty"`
+	UpdatedColumns   int    `json:"updatedColumns,omitempty"`
+	UpdatedCells     int    `json:"updatedCells,omitempty"`
+	Revision         int    `json:"revision,omitempty"`
+}
+
+// SetSheetValuesResponse is the response from PUT /sheets/v2/spreadsheets/:token/values
+type SetSheetValuesResponse struct {
+	Code int                 `json:"code"`
+	Msg  string              `json:"msg"`
+	Data *SetSheetValuesData `json:"data,omitempty"`
+}
+
+// OutputSheetWrite is the sheet write response for CLI
+type OutputSheetWrite struct {
+	Success        bool   `json:"success"`
+	UpdatedRange   string `json:"updated_range"`
+	UpdatedRows    int    `json:"updated_rows"`
+	UpdatedColumns int    `json:"updated_columns"`
+	UpdatedCells   int    `json:"updated_cells"`
+	Revision       int    `json:"revision"`
+}
+
 // --- Bitable Types ---
 
 // BitableTable represents a table in a Bitable app

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -30,8 +30,8 @@ var Groups = map[string]ScopeGroup{
 	"documents": {
 		Name:        "documents",
 		Description: "Lark Docs and Drive access",
-		Scopes:      []string{"docx:document:readonly", "docs:doc:readonly", "docs:document.content:read", "docs:document.comment:read", "drive:drive:readonly", "wiki:wiki:readonly", "space:document:retrieve"},
-		Commands:    []string{"doc"},
+		Scopes:      []string{"docx:document:readonly", "docs:doc:readonly", "docs:document.content:read", "docs:document.comment:read", "drive:drive:readonly", "wiki:wiki:readonly", "space:document:retrieve", "sheets:spreadsheet"},
+		Commands:    []string{"doc", "sheet"},
 	},
 	"bitable": {
 		Name:        "bitable",


### PR DESCRIPTION
## Summary
- Add `PUT` method to API client for Lark Sheets write API
- Add `sheet write` command that writes cell data to spreadsheets via `--values` (JSON array of arrays) or stdin
- Add `sheets:spreadsheet` write scope and register `sheet` command in the documents scope group

## Test plan
- [ ] `make build` compiles successfully
- [ ] `./lark sheet write <token> --values '[["hello","world"],["foo","bar"]]'` writes data
- [ ] `echo '[["a","b"]]' | ./lark sheet write <token> --sheet <id>` reads from stdin
- [ ] `./lark sheet write <token> --sheet <id> --range A1:B2 --values '[["x","y"],["z","w"]]'` targets specific range