### PR TITLE
feat: add chat list and chat members commands

### DIFF
--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -50,3 +50,86 @@ func (c *Client) SearchChats(opts *SearchChatsOptions) ([]Chat, bool, string, er
 
 	return resp.Data.Items, resp.Data.HasMore, resp.Data.PageToken, nil
 }
+
+// ListChatsOptions configures the list chats request
+type ListChatsOptions struct {
+	UserIDType string // open_id, union_id, user_id
+	PageSize   int
+	PageToken  string
+}
+
+// ListChatMembersOptions configures the list chat members request.
+// ChatID is required.
+type ListChatMembersOptions struct {
+	ChatID       string
+	MemberIDType string // open_id, union_id, user_id
+	PageSize     int
+	PageToken    string
+}
+
+// ListChatMembers lists all members of a chat via GET /im/v1/chats/:chat_id/members
+func (c *Client) ListChatMembers(opts *ListChatMembersOptions) ([]ChatMember, bool, string, error) {
+	if opts == nil || opts.ChatID == "" {
+		return nil, false, "", fmt.Errorf("chat_id is required")
+	}
+
+	params := url.Values{}
+	if opts.MemberIDType != "" {
+		params.Set("member_id_type", opts.MemberIDType)
+	}
+	if opts.PageSize > 0 {
+		params.Set("page_size", strconv.Itoa(opts.PageSize))
+	}
+	if opts.PageToken != "" {
+		params.Set("page_token", opts.PageToken)
+	}
+
+	path := fmt.Sprintf("/im/v1/chats/%s/members", url.PathEscape(opts.ChatID))
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	var resp ListChatMembersResponse
+	if err := c.GetWithTenantToken(path, &resp); err != nil {
+		return nil, false, "", err
+	}
+
+	if resp.Code != 0 {
+		return nil, false, "", fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Items, resp.Data.HasMore, resp.Data.PageToken, nil
+}
+
+// ListChats lists all chats the bot has joined via GET /im/v1/chats
+func (c *Client) ListChats(opts *ListChatsOptions) ([]Chat, bool, string, error) {
+	params := url.Values{}
+
+	if opts != nil {
+		if opts.UserIDType != "" {
+			params.Set("user_id_type", opts.UserIDType)
+		}
+		if opts.PageSize > 0 {
+			params.Set("page_size", strconv.Itoa(opts.PageSize))
+		}
+		if opts.PageToken != "" {
+			params.Set("page_token", opts.PageToken)
+		}
+	}
+
+	path := "/im/v1/chats"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	var resp ListChatsResponse
+	if err := c.GetWithTenantToken(path, &resp); err != nil {
+		return nil, false, "", err
+	}
+
+	if resp.Code != 0 {
+		return nil, false, "", fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Items, resp.Data.HasMore, resp.Data.PageToken, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1197,6 +1197,52 @@ type OutputChatList struct {
 	Query string       `json:"query,omitempty"`
 }
 
+// --- Chat Member Types ---
+
+// ChatMember represents a member of a chat group from the IM members API
+// (GET /im/v1/chats/:chat_id/members). Not to be confused with ChatMemberAttendee (Calendar API).
+type ChatMember struct {
+	MemberIDType string `json:"member_id_type,omitempty"`
+	MemberID     string `json:"member_id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	TenantKey    string `json:"tenant_key,omitempty"`
+}
+
+// ListChatMembersResponse is the response from GET /im/v1/chats/:chat_id/members
+type ListChatMembersResponse struct {
+	BaseResponse
+	Data struct {
+		Items       []ChatMember `json:"items,omitempty"`
+		PageToken   string       `json:"page_token,omitempty"`
+		HasMore     bool         `json:"has_more"`
+		MemberCount int          `json:"member_count,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// ListChatsResponse is the response from GET /im/v1/chats
+type ListChatsResponse struct {
+	BaseResponse
+	Data struct {
+		Items     []Chat `json:"items,omitempty"`
+		PageToken string `json:"page_token,omitempty"`
+		HasMore   bool   `json:"has_more"`
+	} `json:"data,omitempty"`
+}
+
+// OutputChatMember is the simplified chat member format for CLI output.
+// OpenID is guaranteed to be an open_id because the API is called with member_id_type=open_id.
+type OutputChatMember struct {
+	OpenID string `json:"open_id"`
+	Name   string `json:"name"`
+}
+
+// OutputChatMemberList is the chat member list response for CLI
+type OutputChatMemberList struct {
+	ChatID  string             `json:"chat_id"`
+	Members []OutputChatMember `json:"members"`
+	Count   int                `json:"count"`
+}
+
 // --- Minutes Types ---
 
 // Minute represents a Lark Minutes recording

--- a/internal/cmd/chat.go
+++ b/internal/cmd/chat.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/yjwong/lark-cli/internal/api"
 	"github.com/yjwong/lark-cli/internal/output"
 )
+
+// maxPaginationPages is a safety limit to prevent infinite pagination loops.
+const maxPaginationPages = 200
 
 var chatCmd = &cobra.Command{
 	Use:   "chat",
@@ -52,7 +57,11 @@ Examples:
 		hasMore := true
 		remaining := chatSearchLimit
 
-		for hasMore {
+		for page := 0; hasMore; page++ {
+			if page >= maxPaginationPages {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("exceeded maximum page count (%d)", maxPaginationPages))
+			}
+
 			pageSize := 50
 			if remaining > 0 && remaining < pageSize {
 				pageSize = remaining
@@ -66,6 +75,10 @@ Examples:
 			}
 
 			allChats = append(allChats, chats...)
+
+			if more && nextToken == pageToken {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("API returned duplicate page token"))
+			}
 			hasMore = more
 			pageToken = nextToken
 
@@ -107,9 +120,179 @@ Examples:
 	},
 }
 
+// --- chat list ---
+
+var (
+	chatListLimit int
+)
+
+var chatListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all chats the bot has joined",
+	Long: `List all group chats that the bot is a member of.
+
+Unlike 'chat search', this uses the /im/v1/chats API which returns
+all chats the bot has joined, regardless of search visibility settings.
+
+Examples:
+  lark chat list
+  lark chat list --limit 20`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewClient()
+
+		opts := &api.ListChatsOptions{}
+
+		var allChats []api.Chat
+		var pageToken string
+		hasMore := true
+		remaining := chatListLimit
+
+		for page := 0; hasMore; page++ {
+			if page >= maxPaginationPages {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("exceeded maximum page count (%d)", maxPaginationPages))
+			}
+
+			pageSize := 50
+			if remaining > 0 && remaining < pageSize {
+				pageSize = remaining
+			}
+			opts.PageSize = pageSize
+			opts.PageToken = pageToken
+
+			chats, more, nextToken, err := client.ListChats(opts)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+
+			allChats = append(allChats, chats...)
+
+			if more && nextToken == pageToken {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("API returned duplicate page token"))
+			}
+			hasMore = more
+			pageToken = nextToken
+
+			if chatListLimit > 0 {
+				remaining = chatListLimit - len(allChats)
+				if remaining <= 0 {
+					break
+				}
+			}
+		}
+
+		if chatListLimit > 0 && len(allChats) > chatListLimit {
+			allChats = allChats[:chatListLimit]
+		}
+
+		outputChats := make([]api.OutputChat, len(allChats))
+		for i, c := range allChats {
+			outputChats[i] = api.OutputChat{
+				ChatID:      c.ChatID,
+				Name:        c.Name,
+				Description: c.Description,
+				OwnerID:     c.OwnerID,
+				External:    c.External,
+				ChatStatus:  c.ChatStatus,
+			}
+		}
+
+		output.JSON(api.OutputChatList{
+			Chats: outputChats,
+			Count: len(outputChats),
+		})
+	},
+}
+
+// --- chat members ---
+
+var (
+	chatMembersLimit int
+)
+
+var chatMembersCmd = &cobra.Command{
+	Use:   "members <chat_id>",
+	Short: "List members of a chat",
+	Long: `List all members of a group chat.
+
+Examples:
+  lark chat members oc_xxxxx
+  lark chat members oc_xxxxx --limit 20`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewClient()
+
+		opts := &api.ListChatMembersOptions{
+			ChatID:       args[0],
+			MemberIDType: "open_id",
+		}
+
+		var allMembers []api.ChatMember
+		var pageToken string
+		hasMore := true
+		remaining := chatMembersLimit
+
+		for page := 0; hasMore; page++ {
+			if page >= maxPaginationPages {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("exceeded maximum page count (%d)", maxPaginationPages))
+			}
+
+			pageSize := 50
+			if remaining > 0 && remaining < pageSize {
+				pageSize = remaining
+			}
+			opts.PageSize = pageSize
+			opts.PageToken = pageToken
+
+			members, more, nextToken, err := client.ListChatMembers(opts)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+
+			allMembers = append(allMembers, members...)
+
+			if more && nextToken == pageToken {
+				output.Fatal("PAGINATION_ERROR", fmt.Errorf("API returned duplicate page token"))
+			}
+			hasMore = more
+			pageToken = nextToken
+
+			if chatMembersLimit > 0 {
+				remaining = chatMembersLimit - len(allMembers)
+				if remaining <= 0 {
+					break
+				}
+			}
+		}
+
+		if chatMembersLimit > 0 && len(allMembers) > chatMembersLimit {
+			allMembers = allMembers[:chatMembersLimit]
+		}
+
+		outputMembers := make([]api.OutputChatMember, len(allMembers))
+		for i, m := range allMembers {
+			outputMembers[i] = api.OutputChatMember{
+				OpenID: m.MemberID,
+				Name:   m.Name,
+			}
+		}
+
+		output.JSON(api.OutputChatMemberList{
+			ChatID:  args[0],
+			Members: outputMembers,
+			Count:   len(outputMembers),
+		})
+	},
+}
+
 func init() {
 	chatSearchCmd.Flags().IntVar(&chatSearchLimit, "limit", 0,
 		"Maximum number of chats to retrieve (0 = no limit)")
+	chatListCmd.Flags().IntVar(&chatListLimit, "limit", 0,
+		"Maximum number of chats to retrieve (0 = no limit)")
+	chatMembersCmd.Flags().IntVar(&chatMembersLimit, "limit", 0,
+		"Maximum number of members to retrieve (0 = no limit)")
 
 	chatCmd.AddCommand(chatSearchCmd)
+	chatCmd.AddCommand(chatListCmd)
+	chatCmd.AddCommand(chatMembersCmd)
 }


### PR DESCRIPTION
## Summary

- Add `chat list` command to list all chats the bot has joined (via `GET /im/v1/chats`), with `--limit` support
- Add `chat members <chat_id>` command to list all members of a chat, with `--limit` support
- Add pagination safety guards (max page count + duplicate token detection) to all chat pagination loops
- Add `member_id_type=open_id` enforcement to ensure consistent member ID output
- Add `url.PathEscape` for chat ID in URL path construction
- Add dedicated `ListChatsResponse` type instead of reusing `SearchChatsResponse`

## New Commands

```bash
# List all chats the bot has joined
lark chat list
lark chat list --limit 20

# List members of a specific chat
lark chat members oc_xxxxx
lark chat members oc_xxxxx --limit 10
```

## Test plan

- [x] `lark chat list` returns bot's chats
- [x] `lark chat list --limit 3` correctly caps results
- [x] `lark chat members <chat_id>` returns all members with open_id format
- [x] `lark chat members <chat_id> --limit 3` correctly caps results
- [x] `lark chat members` (no args) shows proper error
- [x] `lark chat search` (existing command) still works correctly
- [x] Project compiles cleanly with `make build`