### PR TITLE
feat: add sheet write and sheet create commands

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -95,6 +95,11 @@ func (c *Client) Patch(path string, body interface{}, result interface{}) error 
 	return c.doRequest("PATCH", path, body, result)
 }
 
+// Put performs a PUT request
+func (c *Client) Put(path string, body interface{}, result interface{}) error {
+	return c.doRequest("PUT", path, body, result)
+}
+
 // Delete performs a DELETE request
 func (c *Client) Delete(path string, result interface{}) error {
 	return c.doRequest("DELETE", path, nil, result)

--- a/internal/api/sheets.go
+++ b/internal/api/sheets.go
@@ -59,3 +59,50 @@ func (c *Client) GetSheetData(token, rangeStr string) (*SheetValues, error) {
 
 	return resp.Data, nil
 }
+
+// SetSheetData writes cell values to a sheet
+// token: the spreadsheet token
+// sheetRange: the range in format "sheetId!A1:C3"
+// values: 2D array of values to write
+func (c *Client) SetSheetData(token string, sheetRange string, values [][]any) (*SetSheetValuesData, error) {
+	path := fmt.Sprintf("/sheets/v2/spreadsheets/%s/values", url.PathEscape(token))
+
+	req := SetSheetValuesRequest{
+		ValueRange: ValueRange{
+			Range:  sheetRange,
+			Values: values,
+		},
+	}
+
+	var resp SetSheetValuesResponse
+	if err := c.Put(path, req, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data, nil
+}
+
+// CreateSpreadsheet creates a new spreadsheet
+// title: the spreadsheet title
+// folderToken: optional parent folder token (empty = root)
+func (c *Client) CreateSpreadsheet(title, folderToken string) (*SpreadsheetInfo, error) {
+	req := CreateSpreadsheetRequest{
+		Title:       title,
+		FolderToken: folderToken,
+	}
+
+	var resp CreateSpreadsheetResponse
+	if err := c.Post("/sheets/v3/spreadsheets", req, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Spreadsheet, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1388,6 +1388,40 @@ type OutputSheetData struct {
 	Values           [][]any `json:"values"`
 }
 
+// --- Spreadsheet Write Types ---
+
+// SetSheetValuesRequest is the request body for PUT /sheets/v2/spreadsheets/:token/values
+type SetSheetValuesRequest struct {
+	ValueRange ValueRange `json:"valueRange"`
+}
+
+// SetSheetValuesData is the response data from setting sheet values
+type SetSheetValuesData struct {
+	SpreadsheetToken string `json:"spreadsheetToken,omitempty"`
+	UpdatedRange     string `json:"updatedRange,omitempty"`
+	UpdatedRows      int    `json:"updatedRows,omitempty"`
+	UpdatedColumns   int    `json:"updatedColumns,omitempty"`
+	UpdatedCells     int    `json:"updatedCells,omitempty"`
+	Revision         int    `json:"revision,omitempty"`
+}
+
+// SetSheetValuesResponse is the response from PUT /sheets/v2/spreadsheets/:token/values
+type SetSheetValuesResponse struct {
+	Code int                 `json:"code"`
+	Msg  string              `json:"msg"`
+	Data *SetSheetValuesData `json:"data,omitempty"`
+}
+
+// OutputSheetWrite is the sheet write response for CLI
+type OutputSheetWrite struct {
+	Success        bool   `json:"success"`
+	UpdatedRange   string `json:"updated_range"`
+	UpdatedRows    int    `json:"updated_rows"`
+	UpdatedColumns int    `json:"updated_columns"`
+	UpdatedCells   int    `json:"updated_cells"`
+	Revision       int    `json:"revision"`
+}
+
 // --- Bitable Types ---
 
 // BitableTable represents a table in a Bitable app
@@ -1487,4 +1521,38 @@ type OutputBitableRecordList struct {
 type OutputBitableRecord struct {
 	RecordID string         `json:"record_id"`
 	Fields   map[string]any `json:"fields"`
+}
+
+// --- Spreadsheet Create Types ---
+
+// CreateSpreadsheetRequest is the request body for POST /sheets/v3/spreadsheets
+type CreateSpreadsheetRequest struct {
+	Title       string `json:"title"`
+	FolderToken string `json:"folder_token,omitempty"`
+}
+
+// SpreadsheetInfo is the spreadsheet info in create response
+type SpreadsheetInfo struct {
+	Title            string `json:"title"`
+	FolderToken      string `json:"folder_token,omitempty"`
+	URL              string `json:"url,omitempty"`
+	SpreadsheetToken string `json:"spreadsheet_token"`
+}
+
+// CreateSpreadsheetResponse is the response from POST /sheets/v3/spreadsheets
+type CreateSpreadsheetResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Spreadsheet *SpreadsheetInfo `json:"spreadsheet,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+// OutputSpreadsheetCreate is the create spreadsheet response for CLI
+type OutputSpreadsheetCreate struct {
+	Success          bool   `json:"success"`
+	SpreadsheetToken string `json:"spreadsheet_token"`
+	Title            string `json:"title"`
+	URL              string `json:"url"`
+	FolderToken      string `json:"folder_token,omitempty"`
 }

--- a/internal/cmd/sheet.go
+++ b/internal/cmd/sheet.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/yjwong/lark-cli/internal/api"
@@ -188,12 +191,155 @@ func columnIndexToLetter(index int) string {
 	return string(rune('A' + index - 1))
 }
 
+// --- sheet create ---
+
+var sheetCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new spreadsheet",
+	Long: `Create a new Lark spreadsheet.
+
+Examples:
+  lark sheet create --title "My Spreadsheet"
+  lark sheet create --title "My Spreadsheet" --folder fldbcRho46N6MQ3mJkOAuPabcef`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		title, _ := cmd.Flags().GetString("title")
+		folderToken, _ := cmd.Flags().GetString("folder")
+
+		if title == "" {
+			output.Fatal("MISSING_ARG", fmt.Errorf("--title is required"))
+		}
+
+		client := api.NewClient()
+
+		spreadsheet, err := client.CreateSpreadsheet(title, folderToken)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		result := api.OutputSpreadsheetCreate{
+			Success:          true,
+			SpreadsheetToken: spreadsheet.SpreadsheetToken,
+			Title:            spreadsheet.Title,
+			URL:              spreadsheet.URL,
+			FolderToken:      spreadsheet.FolderToken,
+		}
+
+		output.JSON(result)
+	},
+}
+
+// --- sheet write ---
+
+var sheetWriteCmd = &cobra.Command{
+	Use:   "write <spreadsheet_token>",
+	Short: "Write cell data to a sheet",
+	Long: `Write cell values to a Lark spreadsheet.
+
+Values are provided as a JSON array of arrays via --values or stdin.
+
+By default, writes to the first sheet starting at A1.
+Use --sheet to specify a sheet ID, and --range to specify a target range.
+
+The spreadsheet_token is from the spreadsheet URL.
+
+Examples:
+  lark sheet write T4mHsrFyzhXrj0tVzRslUGx8gkA --values '[["hello","world"],["foo","bar"]]'
+  lark sheet write T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123 --range A1:B2 --values '[["a","b"],["c","d"]]'
+  echo '[["a","b"]]' | lark sheet write T4mHsrFyzhXrj0tVzRslUGx8gkA`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		token := args[0]
+		sheetID, _ := cmd.Flags().GetString("sheet")
+		rangeSpec, _ := cmd.Flags().GetString("range")
+		valuesJSON, _ := cmd.Flags().GetString("values")
+
+		client := api.NewClient()
+
+		// If no sheet ID specified, get the first sheet
+		if sheetID == "" {
+			sheets, err := client.GetSpreadsheetSheets(token)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+			if len(sheets) == 0 {
+				output.Fatal("NO_SHEETS", fmt.Errorf("spreadsheet has no sheets"))
+			}
+			firstSheet := sheets[0]
+			for _, s := range sheets[1:] {
+				if s.Index < firstSheet.Index {
+					firstSheet = s
+				}
+			}
+			sheetID = firstSheet.SheetID
+		}
+
+		// Parse values from --values flag or stdin
+		if valuesJSON == "" {
+			// Try reading from stdin
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					output.Fatal("INPUT_ERROR", fmt.Errorf("failed to read stdin: %w", err))
+				}
+				valuesJSON = string(data)
+			}
+		}
+
+		if valuesJSON == "" {
+			output.Fatal("MISSING_ARG", fmt.Errorf("--values is required or provide JSON via stdin"))
+		}
+
+		var values [][]any
+		if err := json.Unmarshal([]byte(valuesJSON), &values); err != nil {
+			output.Fatal("PARSE_ERROR", fmt.Errorf("invalid values JSON (must be array of arrays): %w", err))
+		}
+
+		// Build the range string
+		if rangeSpec == "" {
+			rangeSpec = "A1"
+		}
+		fullRange := sheetID + "!" + rangeSpec
+
+		// Write the data
+		data, err := client.SetSheetData(token, fullRange, values)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		result := api.OutputSheetWrite{
+			Success: true,
+		}
+		if data != nil {
+			result.UpdatedRange = data.UpdatedRange
+			result.UpdatedRows = data.UpdatedRows
+			result.UpdatedColumns = data.UpdatedColumns
+			result.UpdatedCells = data.UpdatedCells
+			result.Revision = data.Revision
+		}
+
+		output.JSON(result)
+	},
+}
+
 func init() {
 	// Register subcommands
 	sheetCmd.AddCommand(sheetListCmd)
 	sheetCmd.AddCommand(sheetReadCmd)
+	sheetCmd.AddCommand(sheetWriteCmd)
+	sheetCmd.AddCommand(sheetCreateCmd)
 
 	// Flags for sheet read
 	sheetReadCmd.Flags().String("sheet", "", "Sheet ID to read from (default: first sheet)")
 	sheetReadCmd.Flags().String("range", "", "Cell range to read (e.g., A1:Z100)")
+
+	// Flags for sheet write
+	sheetWriteCmd.Flags().String("sheet", "", "Sheet ID to write to (default: first sheet)")
+	sheetWriteCmd.Flags().String("range", "", "Target range in A1 notation (e.g., A1:C3, default: A1)")
+	sheetWriteCmd.Flags().String("values", "", "JSON array of arrays (e.g., '[[\"a\",\"b\"],[\"c\",\"d\"]]')")
+
+	// Flags for sheet create
+	sheetCreateCmd.Flags().String("title", "", "Spreadsheet title (required)")
+	sheetCreateCmd.Flags().String("folder", "", "Folder token to create the spreadsheet in (default: root)")
 }


### PR DESCRIPTION
## Summary

- Add `lark sheet write` command to write cell values (JSON array of arrays) to a sheet, supporting both `--values` flag and stdin piping
- Add `lark sheet create` command to create new spreadsheets with `--title` (required) and optional `--folder` token
- Add `Put` HTTP method to API client
- Add `SetSheetData` and `CreateSpreadsheet` API methods with supporting types

## Usage

```bash
# Create a spreadsheet
lark sheet create --title "My Analysis" --folder <folder_token>

# Write data
lark sheet write <token> --values '[["Header1","Header2"],["val1","val2"]]'
echo '[["a","b"]]' | lark sheet write <token>
lark sheet write <token> --sheet abc123 --range A1:B2 --values '[["a","b"],["c","d"]]'
```

## Test plan

- [ ] `lark sheet create --title "Test"` creates a spreadsheet and returns token + URL
- [ ] `lark sheet write <token> --values '[["a","b"]]'` writes values and returns updated range/rows/cells
- [ ] Stdin piping works: `echo '[["x"]]' | lark sheet write <token>`
- [ ] Missing `--title` on create returns a clear error
- [ ] No merge conflicts with origin/main