### PR TITLE
feat: add sheet condition-format command

### DIFF
--- a/internal/api/sheets.go
+++ b/internal/api/sheets.go
@@ -59,3 +59,17 @@ func (c *Client) GetSheetData(token, rangeStr string) (*SheetValues, error) {
 
 	return resp.Data, nil
 }
+
+// BatchCreateConditionFormats applies conditional formatting rules to sheet ranges
+func (c *Client) BatchCreateConditionFormats(token string, formats []SheetConditionFormat) ([]ConditionFormatResponse, error) {
+	path := fmt.Sprintf("/sheets/v2/spreadsheets/%s/condition_formats/batch_create", url.PathEscape(token))
+	req := BatchCreateConditionFormatsRequest{SheetConditionFormats: formats}
+	var resp BatchCreateConditionFormatsResponse
+	if err := c.Post(path, req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+	return resp.Data.Responses, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1488,3 +1488,60 @@ type OutputBitableRecord struct {
 	RecordID string         `json:"record_id"`
 	Fields   map[string]any `json:"fields"`
 }
+
+// --- Condition Format Types ---
+
+type ConditionFormatFont struct {
+	Bold   bool `json:"bold,omitempty"`
+	Italic bool `json:"italic,omitempty"`
+}
+
+type ConditionFormatStyle struct {
+	Font           *ConditionFormatFont `json:"font,omitempty"`
+	ForeColor      string               `json:"fore_color,omitempty"`
+	BackColor      string               `json:"back_color,omitempty"`
+	TextDecoration int                  `json:"text_decoration,omitempty"`
+}
+
+type ConditionFormatAttr struct {
+	Operator   string   `json:"operator,omitempty"`
+	Formula    []string `json:"formula,omitempty"`
+	Text       string   `json:"text,omitempty"`
+	TimePeriod string   `json:"time_period,omitempty"`
+}
+
+type ConditionFormat struct {
+	Ranges   []string              `json:"ranges"`
+	RuleType string                `json:"rule_type"`
+	Attrs    []ConditionFormatAttr `json:"attrs,omitempty"`
+	Style    ConditionFormatStyle  `json:"style"`
+}
+
+type SheetConditionFormat struct {
+	SheetID         string          `json:"sheet_id"`
+	ConditionFormat ConditionFormat `json:"condition_format"`
+}
+
+type BatchCreateConditionFormatsRequest struct {
+	SheetConditionFormats []SheetConditionFormat `json:"sheet_condition_formats"`
+}
+
+type ConditionFormatResponse struct {
+	CfID    string `json:"cf_id"`
+	ResCode int    `json:"res_code"`
+	ResMsg  string `json:"res_msg"`
+	SheetID string `json:"sheet_id"`
+}
+
+type BatchCreateConditionFormatsResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Responses []ConditionFormatResponse `json:"responses"`
+	} `json:"data"`
+}
+
+type OutputConditionFormat struct {
+	Success   bool                      `json:"success"`
+	Responses []ConditionFormatResponse `json:"responses"`
+}


### PR DESCRIPTION
## Summary

- Adds `sheet condition-format` subcommand to apply conditional formatting rules to Lark spreadsheet ranges
- Implements `BatchCreateConditionFormats` API method calling `POST /sheets/v2/spreadsheets/:token/condition_formats/batch_create`
- Adds all necessary types: `ConditionFormat`, `SheetConditionFormat`, `ConditionFormatStyle`, `ConditionFormatAttr`, etc.

## Usage

```bash
# Red background for values > 50
lark sheet condition-format <token> --sheet abc123 --range "abc123!E2:K100" --operator greaterThan --value 50 --bg-color "#FFcccc"

# Green background for values <= 50
lark sheet condition-format <token> --sheet abc123 --range "abc123!E2:K100" --operator lessThanOrEqual --value 50 --bg-color "#d9f5d6"
```

## Flags

| Flag | Required | Default | Description |
|------|----------|---------|-------------|
| `--sheet` | Yes | - | Sheet ID |
| `--range` | Yes | - | Cell range (e.g. `abc123!E2:K100`) |
| `--rule` | No | `cellIs` | Rule type |
| `--operator` | No | `greaterThan` | Operator for `cellIs` |
| `--value` | No | - | Threshold value |
| `--value2` | No | - | Second value for `between`/`notBetween` |
| `--bg-color` | No | `#FFcccc` | Background color hex |
| `--fg-color` | No | - | Foreground/text color hex |