### PR TITLE
feat(sheet): add style, resize, and add-tab commands

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1613,3 +1613,96 @@ type OutputSpreadsheetCreate struct {
 	URL              string `json:"url"`
 	FolderToken      string `json:"folder_token,omitempty"`
 }
+
+// --- Sheet Style Types ---
+
+type SheetStyleFont struct {
+	Bold bool `json:"bold,omitempty"`
+}
+
+type SheetStyle struct {
+	Font *SheetStyleFont `json:"font,omitempty"`
+}
+
+type SheetStyleItem struct {
+	Ranges []string   `json:"ranges"`
+	Style  SheetStyle `json:"style"`
+}
+
+type SheetStyleBatchUpdateRequest struct {
+	Data []SheetStyleItem `json:"data"`
+}
+
+type SheetStyleBatchUpdateResponse struct {
+	BaseResponse
+}
+
+type OutputSheetStyle struct {
+	Success bool `json:"success"`
+}
+
+// --- Sheet Dimension (Resize) Types ---
+
+type SheetDimension struct {
+	SheetID        string `json:"sheetId"`
+	MajorDimension string `json:"majorDimension"`
+	StartIndex     int    `json:"startIndex"`
+	EndIndex       int    `json:"endIndex"`
+}
+
+type SheetDimensionProperties struct {
+	FixedSize int `json:"fixedSize"`
+}
+
+type SheetDimensionRangeRequest struct {
+	Dimension            SheetDimension           `json:"dimension"`
+	DimensionProperties  SheetDimensionProperties `json:"dimensionProperties"`
+}
+
+type SheetDimensionRangeResponse struct {
+	BaseResponse
+}
+
+type OutputSheetResize struct {
+	Success    bool `json:"success"`
+	ColumnsSet int  `json:"columns_set"`
+}
+
+// --- Add Sheet Tab Types ---
+
+type AddSheetProperties struct {
+	Title string `json:"title"`
+	Index int    `json:"index"`
+}
+
+type AddSheetRequestItem struct {
+	AddSheet struct {
+		Properties AddSheetProperties `json:"properties"`
+	} `json:"addSheet"`
+}
+
+type AddSheetBatchRequest struct {
+	Requests []AddSheetRequestItem `json:"requests"`
+}
+
+type AddSheetBatchResponse struct {
+	BaseResponse
+	Data struct {
+		Replies []struct {
+			AddSheet struct {
+				Properties struct {
+					SheetID string `json:"sheetId"`
+					Title   string `json:"title"`
+					Index   int    `json:"index"`
+				} `json:"properties"`
+			} `json:"addSheet"`
+		} `json:"replies"`
+	} `json:"data,omitempty"`
+}
+
+type OutputSheetAddTab struct {
+	Success bool   `json:"success"`
+	SheetID string `json:"sheet_id"`
+	Title   string `json:"title"`
+	Index   int    `json:"index"`
+}


### PR DESCRIPTION
## Summary

- **`lark sheet style`** - Apply bold formatting to a cell range via `--range` and `--bold`
- **`lark sheet resize`** - Set pixel widths for columns: per-column via `--widths '{"0":60,"1":280,...}'` or uniform via `--all <px> --cols <n>`
- **`lark sheet add-tab`** - Add a new sheet tab to an existing spreadsheet at a given index

Also refactors the repeated first-sheet resolution logic (previously copy-pasted across read, write, and new commands) into a shared `resolveSheetID` helper.

## Changes

- `internal/api/sheets.go` - `SetSheetColumnWidths`, `SetSheetStyleBold`, `AddSheetTab` API methods
- `internal/api/types.go` - Supporting request/response types using typed structs throughout
- `internal/cmd/sheet.go` - Three new subcommands + `resolveSheetID` helper

## Test plan

- [ ] `lark sheet style <token> --range A1:Q1 --bold` - header row becomes bold
- [ ] `lark sheet resize <token> --widths '{"0":60,"1":280}'` - columns resize correctly
- [ ] `lark sheet resize <token> --all 200 --cols 10` - uniform resize
- [ ] `lark sheet add-tab <token> --title "README" --index 0` - new tab appears at position 0
- [ ] `lark sheet resize <token> --widths '{"abc":100}'` - errors with clear message about non-numeric key
- [ ] All commands default to first sheet when `--sheet` is omitted