### PR TITLE
feat: add add-ons block support for reading Mermaid diagrams

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -752,6 +752,7 @@ Block types:
 - 22: Divider
 - 27: Image
 - 31: Table
+- 40: Add-Ons (e.g., Mermaid diagrams — content in `add_ons.record`)
 
 #### Get Document Comments
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -641,6 +641,13 @@ type ImageBlock struct {
 // DividerBlock represents a divider (horizontal rule) in a document
 type DividerBlock struct{}
 
+// AddOnsBlock represents an add-ons block (e.g., Mermaid diagrams) in a document
+type AddOnsBlock struct {
+	ComponentID     string `json:"component_id,omitempty"`
+	ComponentTypeID string `json:"component_type_id,omitempty"`
+	Record          string `json:"record,omitempty"` // Content data as JSON string
+}
+
 // DocumentBlock represents a block in a document
 type DocumentBlock struct {
 	BlockID   string      `json:"block_id,omitempty"`
@@ -664,7 +671,8 @@ type DocumentBlock struct {
 	Quote     *TextBlock  `json:"quote,omitempty"`
 	TodoBlock *TextBlock  `json:"todo,omitempty"`
 	Divider   *DividerBlock `json:"divider,omitempty"`
-	Image     *ImageBlock `json:"image,omitempty"`
+	Image     *ImageBlock  `json:"image,omitempty"`
+	AddOns    *AddOnsBlock `json:"add_ons,omitempty"` // type 40
 }
 
 // --- Document API Response Types ---

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -440,6 +440,7 @@ When using `doc blocks`, key block types:
 | 22 | Divider |
 | 27 | Image |
 | 31 | Table |
+| 40 | Add-Ons (e.g., Mermaid diagrams) |
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
Add support for document add-ons blocks (`block_type: 40`) in `doc blocks` output.

## Why
Some Lark documents embed Mermaid diagrams and similar content as add-ons blocks. We were already fetching document blocks, but the `add_ons` payload was not modeled in `DocumentBlock`, so fields like `add_ons.record` were not exposed in the decoded output.

## Changes
- add `AddOnsBlock` to the document API types
- add `DocumentBlock.AddOns` for `add_ons` payloads
- document block type `40` in the usage docs and document skill docs

## Impact
`lark doc blocks <document_id>` now includes add-ons block data, which makes Mermaid diagram payloads readable from the CLI response.

## Risk
Low. This only expands response decoding for document blocks and updates documentation. Existing request paths and block handling are otherwise unchanged.

## Testing
Manual/schema-level verification only.
